### PR TITLE
Fix various issues with the sync of a PDA

### DIFF
--- a/jpilot.c
+++ b/jpilot.c
@@ -994,7 +994,7 @@ gboolean cb_read_pipe_from_child(GIOChannel *channel, GIOCondition cond, gpointe
             }
         }
     }
-    return FALSE;
+    return TRUE;
 }
 
 static void cb_about(GtkWidget *widget, gpointer data) {


### PR DESCRIPTION
The cb_read_pipe_from_child was set to return FALSE when it completed.
It should have been set to return TRUE.
Calling FALSE closes the IO channel, and is meant for when there is an error.
