### PR TITLE
tweaked output of int to hex to spit out 2 digits intead of truncating to one for numbers like 0.

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -3193,7 +3193,7 @@ GdkRGBA get_color(int r, int g, int b) {
     GdkRGBA color;
     char rgb[50];
     sprintf(rgb, "#%02X%02X%02X", r,g,b);
-    gdk_rgba_parse(&color,"#D90000");
+    gdk_rgba_parse(&color,rgb);
     return color;
 }
 

--- a/utils.c
+++ b/utils.c
@@ -3189,14 +3189,15 @@ int rename_file(char *old_filename, char *new_filename) {
 
     return rename(old_fullname, new_fullname);
 }
-
 GdkRGBA get_color(int r, int g, int b) {
     GdkRGBA color;
     char rgb[50];
-    sprintf(rgb, "#%X%X%X", r,g,b);
-    gdk_rgba_parse(&color,rgb);
+    sprintf(rgb, "#%02X%02X%02X", r,g,b);
+    gdk_rgba_parse(&color,"#D90000");
     return color;
 }
+
+
 
 
 int setup_sync(unsigned int flags) {


### PR DESCRIPTION
This should remove these warnings..
Gtk-WARNING **: Don't know color ...