### PR TITLE
Fix unfocused color theme

### DIFF
--- a/jpilotcss.blue
+++ b/jpilotcss.blue
@@ -34,7 +34,7 @@ insensitive text widgets and the like base background color */
 @define-color insensitive_base_color #d9e6ff;
 /*-
 widget text/foreground color on backdrop windows */
-@define-color theme_unfocused_fg_color #004C99;
+@define-color theme_unfocused_fg_color white;
 /*-
 text color for entries, views and content in general on backdrop windows */
 @define-color theme_unfocused_text_color white;
@@ -3451,7 +3451,7 @@ treeview.view header button:backdrop {
     border-color: @theme_bg_color;
     border-style: none solid solid none;
     background-image: none;
-    background-color: @theme_unfocused_base_color;
+    background-color: @theme_bg_color;
 }
 
 treeview.view header button:backdrop:disabled {

--- a/jpilotcss.green
+++ b/jpilotcss.green
@@ -34,7 +34,7 @@ insensitive text widgets and the like base background color */
 @define-color insensitive_base_color #c1e6e6;
 /*-
 widget text/foreground color on backdrop windows */
-@define-color theme_unfocused_fg_color #007F7F;
+@define-color theme_unfocused_fg_color white;
 /*-
 text color for entries, views and content in general on backdrop windows */
 @define-color theme_unfocused_text_color white;
@@ -3451,7 +3451,7 @@ treeview.view header button:backdrop {
     border-color: @theme_bg_color;
     border-style: none solid solid none;
     background-image: none;
-    background-color: @theme_unfocused_base_color;
+    background-color: @theme_bg_color;
 }
 
 treeview.view header button:backdrop:disabled {

--- a/jpilotcss.purple
+++ b/jpilotcss.purple
@@ -34,7 +34,7 @@ insensitive text widgets and the like base background color */
 @define-color insensitive_base_color #d6e9ff;
 /*-
 widget text/foreground color on backdrop windows */
-@define-color theme_unfocused_fg_color #663399;
+@define-color theme_unfocused_fg_color white;
 /*-
 text color for entries, views and content in general on backdrop windows */
 @define-color theme_unfocused_text_color white;
@@ -3451,7 +3451,7 @@ treeview.view header button:backdrop {
     border-color: @theme_bg_color;
     border-style: none solid solid none;
     background-image: none;
-    background-color: @theme_unfocused_base_color;
+    background-color: @theme_bg_color;
 }
 
 treeview.view header button:backdrop:disabled {

--- a/jpilotcss.steel
+++ b/jpilotcss.steel
@@ -34,7 +34,7 @@ insensitive text widgets and the like base background color */
 @define-color insensitive_base_color #d9e6ff;
 /*-
 widget text/foreground color on backdrop windows */
-@define-color theme_unfocused_fg_color #666699;
+@define-color theme_unfocused_fg_color white;
 /*-
 text color for entries, views and content in general on backdrop windows */
 @define-color theme_unfocused_text_color white;
@@ -3451,7 +3451,7 @@ treeview.view header button:backdrop {
     border-color: @theme_bg_color;
     border-style: none solid solid none;
     background-image: none;
-    background-color: @theme_unfocused_base_color;
+    background-color: @theme_bg_color;
 }
 
 treeview.view header button:backdrop:disabled {


### PR DESCRIPTION
This should make text that turns 'invisible'
when the application looses focus visible.
Its kinda noticeable when 'alarm' popups come up and the buttons are blank when using a theme that 
isn't the default.