### PR TITLE
2 bug fixes.

### DIFF
--- a/datebook_gui.c
+++ b/datebook_gui.c
@@ -273,12 +273,6 @@ void deleteDateRecordFromDataStructure(MyCalendarEvent *mcale, gpointer data);
 
 void undeleteDate(MyCalendarEvent *mcale, gpointer data);
 
-gboolean
-clickedTodoButton(GtkTreeSelection *selection,
-                  GtkTreeModel *model,
-                  GtkTreePath *path,
-                  gboolean path_currently_selected,
-                  gpointer userdata);
 
 gint cb_todo_treeview_selection_event(GtkWidget *widget,
                                       GdkEvent *event,
@@ -5877,8 +5871,6 @@ void buildToDoList(const GtkWidget *vbox) {
     selectFirstTodoRow();
     todo_treeSelection = gtk_tree_view_get_selection(GTK_TREE_VIEW(todo_treeView));
 
-    gtk_tree_selection_set_select_function(todo_treeSelection, clickedTodoButton, NULL, NULL);
-
     g_signal_connect (todo_treeView, "button_release_event", G_CALLBACK(cb_todo_treeview_selection_event), NULL);
     gtk_container_add(GTK_CONTAINER(todo_scrolled_window), GTK_WIDGET(todo_treeView));
 }
@@ -5893,30 +5885,20 @@ void selectFirstTodoRow() {
     gtk_tree_path_free(path);
 }
 
-gboolean
-clickedTodoButton(GtkTreeSelection *selection,
-                  GtkTreeModel *model,
-                  GtkTreePath *path,
-                  gboolean path_currently_selected,
-                  gpointer userdata) {
-    GtkTreeIter iter;
-    MyToDo *mtodo;
-    if ((gtk_tree_model_get_iter(model, &iter, path)) && (!path_currently_selected)) {
-
-        gtk_tree_model_get(model, &iter, TODO_DATA_COLUMN_ENUM, &mtodo, -1);
-        if (mtodo == NULL) {
-            return TRUE;
-        }
-        glob_find_id = mtodo->unique_id;
-        return TRUE;
-    }
-    return TRUE;
-}
-
 gint cb_todo_treeview_selection_event(GtkWidget *widget,
                                       GdkEvent *event,
                                       gpointer callback_data) {
+    GtkTreeSelection *selection;
+    GtkTreeModel *model;
+    GtkTreeIter iter;
+    MyToDo *mtodo;
     if (!event) return 1;
+
+    selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (widget));
+    gtk_tree_selection_get_selected(selection, &model, &iter);
+    gtk_tree_model_get(model, &iter, TODO_DATA_COLUMN_ENUM, &mtodo, -1);
+    jp_logf(JP_LOG_WARN,"cb_todo_treeview_selection_event id %d\n",mtodo->unique_id);
+    glob_find_id = mtodo->unique_id;
     cb_app_button(NULL, GINT_TO_POINTER(TODO));
     return 1;
 }

--- a/datebook_gui.c
+++ b/datebook_gui.c
@@ -5895,10 +5895,13 @@ gint cb_todo_treeview_selection_event(GtkWidget *widget,
     if (!event) return 1;
 
     selection = gtk_tree_view_get_selection (GTK_TREE_VIEW (widget));
-    gtk_tree_selection_get_selected(selection, &model, &iter);
-    gtk_tree_model_get(model, &iter, TODO_DATA_COLUMN_ENUM, &mtodo, -1);
-    jp_logf(JP_LOG_WARN,"cb_todo_treeview_selection_event id %d\n",mtodo->unique_id);
-    glob_find_id = mtodo->unique_id;
-    cb_app_button(NULL, GINT_TO_POINTER(TODO));
+    if(selection != NULL) {
+        gtk_tree_selection_get_selected(selection, &model, &iter);
+        gtk_tree_model_get(model, &iter, TODO_DATA_COLUMN_ENUM, &mtodo, -1);
+        glob_find_id = mtodo->unique_id;
+        //gtk_selection_data_free(selection);
+        cb_app_button(NULL, GINT_TO_POINTER(TODO));
+    }
+
     return 1;
 }

--- a/todo_gui.c
+++ b/todo_gui.c
@@ -1637,7 +1637,8 @@ static void checkedCallBack(GtkCellRendererToggle *renderer, gchar *path, GtkLis
     gboolean active;
     MyToDo *mtodo;
     active = gtk_cell_renderer_toggle_get_active(renderer);
-
+    unsigned char attrib = 0;
+    unsigned int unique_id = 0;
     gtk_tree_model_get_iter_from_string(GTK_TREE_MODEL (model), &iter, path);
     gtk_tree_model_get(GTK_TREE_MODEL(model), &iter, TODO_DATA_COLUMN_ENUM, &mtodo, -1);
     if (active) {
@@ -1648,6 +1649,15 @@ static void checkedCallBack(GtkCellRendererToggle *renderer, gchar *path, GtkLis
         // gtk_cell_renderer_set_alignment(GTK_CELL_RENDERER(renderer), 0.5, 0.5);
         gtk_list_store_set(GTK_LIST_STORE (model), &iter, TODO_CHECK_COLUMN_ENUM, TRUE, -1);
         mtodo->todo.complete = 1;
+    }
+    attrib = mtodo ->attrib;
+    unique_id = mtodo ->unique_id;
+    delete_pc_record(TODO, mtodo, MODIFY_FLAG);
+    if ((mtodo->rt == PALM_REC) || (mtodo->rt == REPLACEMENT_PALM_REC)) {
+        pc_todo_write(&(mtodo ->todo), REPLACEMENT_PALM_REC, attrib, &unique_id);
+    } else {
+        unique_id = 0;
+        pc_todo_write(&(mtodo -> todo), NEW_PC_REC, attrib, &unique_id);
     }
 }
 


### PR DESCRIPTION
bug1.
On the todo page, clicking the checkbox in the list on  the 1.8.x version, would cause the checkbox to be selected on the right,
and it would cause the checkbox change to be saved.
In 2.x version, while it causes the checkbox to be selected on the right, it wasn't causing the change to be saved.  This could lead to confusion of the end-user thinking the change was saved, when it was not.  
This now saving the checkbox change when the checkbox is selected on the tree.

bug2.
On the datebook, one has the option of viewing the todos.  In the 1.8.x version, when clicking on a todo row, it would open up the todo screen, and select the todo you clicked on.  In the 2.x version, it would just open up the todo screen, and leave the first todo selected.  This pull request re-enables that selection of the todo.