### PR TITLE
Fix broken types from latest pilot-link changes

### DIFF
--- a/contact.c
+++ b/contact.c
@@ -442,7 +442,7 @@ int copy_address_to_contact(const struct Address *a, struct Contact *c)
    c->advance = 0;
    c->advanceUnits = 0;    
    memset(&(c->birthday), 0, sizeof(struct tm));
-   for (i=0; i<MAX_CONTACT_BLOBS; i++) {
+   for (i=0; i<MAX_BLOBS; i++) {
       c->blob[i] = NULL;
    }
    c->picture = NULL;

--- a/jp-contact.c
+++ b/jp-contact.c
@@ -54,7 +54,7 @@ int jp_pack_Contact(struct Contact *c, pi_buffer_t *buf)
    return pack_Contact(c, buf, contacts_v10);
 }
 
-int jp_Contact_add_blob(struct Contact *c, struct ContactBlob *blob)
+int jp_Contact_add_blob(struct Contact *c, Blob_t *blob)
 {
    return Contact_add_blob(c, blob);
 }

--- a/jp-pi-contact.h
+++ b/jp-pi-contact.h
@@ -47,7 +47,7 @@ extern int jp_pack_ContactAppInfo
     PI_ARGS((struct ContactAppInfo *, pi_buffer_t *buf));
 
 extern int jp_Contact_add_blob
-    PI_ARGS((struct Contact *, struct ContactBlob *));
+    PI_ARGS((struct Contact *, Blob_t *));
 extern int jp_Contact_add_picture
     PI_ARGS((struct Contact *, struct ContactPicture *));
 #ifdef __cplusplus


### PR DESCRIPTION
Last year an update to the pilot link source broke this, it's part of the patch from here https://github.com/desrod/pilot-link/pull/3

This is simply updating the types to match the changes

This fixes the compilation errors around MAX_CONTACT_BLOBS

**Note** I'm not entirely sure which branch is the development branch since the master branch is still 1.8 something and the only branch that seems close to v2.0.3 tag is the feature-gtk branch?