### PR TITLE
SQLite storage

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,4 +1,4 @@
-SUBDIRS = m4 po Expense SyncTime KeyRing dialer icons docs empty
+SUBDIRS = m4 po Expense jpsqlite SyncTime KeyRing dialer icons docs empty
 
 EXTRA_DIST = config.rpath mkinstalldirs reconf autogen.sh \
 	intltool-extract.in intltool-merge.in intltool-update.in gettext.h \
@@ -58,6 +58,8 @@ jpilot_SOURCES = \
 	jp-pi-contact.h \
 	libplugin.c \
 	libplugin.h \
+	libsqlite.c \
+	libsqlite.h \
 	log.c \
 	log.h \
 	memo.c \
@@ -119,6 +121,8 @@ jpilot_dump_SOURCES = \
 	japanese.c \
 	jpilot-dump.c \
 	libplugin.c \
+	libsqlite.c \
+	libsqlite.h \
 	log.c \
 	memo.c \
 	otherconv.c \
@@ -136,6 +140,10 @@ jpilot_sync_SOURCES = \
 	jpilot-sync.c \
 	japanese.c \
 	libplugin.c \
+	libsqlite.c \
+	libsqlite.h \
+	datebook.c \
+	calendar.c \
 	log.c \
 	otherconv.c \
 	password.c \
@@ -150,6 +158,11 @@ jpilot_merge_SOURCES = \
 	cp1250.c \
 	japanese.c \
 	libplugin.c \
+	libsqlite.c \
+	libsqlite.h \
+	datebook.c \
+	calendar.c \
+	password.c \
 	log.c \
 	jpilot-merge.c \
 	otherconv.c \
@@ -171,11 +184,11 @@ AM_CFLAGS= @PILOT_FLAGS@ @GTK_CFLAGS@ ${I18NDEFS}
 
 # Add linkflags
 jpilot_LDFLAGS = -export-dynamic
-jpilot_LDADD=@LIBS@ @PILOT_LIBS@ @GTK_LIBS@
-jpilot_dump_LDADD=@LIBS@ @PILOT_LIBS@ @GTK_LIBS@
+jpilot_LDADD=@LIBS@ @PILOT_LIBS@ @GTK_LIBS@ -lsqlite3
+jpilot_dump_LDADD=@LIBS@ @PILOT_LIBS@ @GTK_LIBS@ -lsqlite3
 jpilot_sync_LDFLAGS = -export-dynamic
-jpilot_sync_LDADD=@LIBS@ @PILOT_LIBS@ @GTK_LIBS@
-jpilot_merge_LDADD=@LIBS@ @PILOT_LIBS@ @GTK_LIBS@
+jpilot_sync_LDADD=@LIBS@ @PILOT_LIBS@ @GTK_LIBS@ -lsqlite3
+jpilot_merge_LDADD=@LIBS@ @PILOT_LIBS@ @GTK_LIBS@ -lsqlite3
 
 ################################################################################
 ## The rest of the file is copied over to the Makefile with only variable

--- a/docs/jpilot.man
+++ b/docs/jpilot.man
@@ -1,8 +1,8 @@
-.TH J-PILOT 1 "November 22, 2005"
+.TH J-PILOT 1 "March 28, 2023"
 .SH NAME
 jpilot \- A palm pilot desktop for Linux/Unix
 .SH SYNOPSIS
-.B jpilot [-v] [-h] [-d] [-a] [-A] [-i] [-s]
+.B jpilot [-v] [-h] [-d] [-A] [-a] [-i] [-p] [-r] [-S] [-s]
 .SH "DESCRIPTION"
 J-Pilot is a desktop organizer application for the palm pilot and other
 Palm OS devices.  It is similar in functionality to the one that
@@ -18,21 +18,30 @@ displays help and exits.
 .B \-d
 displays debug info to stdout.
 .TP
+.B \-A
+ignore all alarms, past and future.
+.TP
 .B \-a
 ignores missed alarms since the last time program was run.
-.TP
-.B \-A
-ignores all alarms, past and future.
 .TP
 .B \-i 
 makes 
 .B jpilot
 iconify itself upon launch.
 .TP
+.B \-p
+does not load plugins.
+.TP
+.TP
+.B \-r
+no writing to rc-file or PREF-table
 .B \-s 
 initiates a sync on the running
 .B jpilot
 instance.
+.TP
+.B \-S
+store data in SQLite database.
 
 If you have more than one 
 .B jpilot 

--- a/import_gui.c
+++ b/import_gui.c
@@ -162,7 +162,7 @@ static void cb_quit(GtkWidget *widget, gpointer data)
    char dir[MAX_PREF_LEN+2];
    int i;
 
-   jp_logf(JP_LOG_DEBUG, "Quit\n");
+   jp_logf(JP_LOG_DEBUG, "import_gui.c:cb_quit(): Quit\n");
 
    sel = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(widget));
    strncpy(dir, sel, MAX_PREF_LEN);
@@ -193,7 +193,7 @@ static void cb_import(GtkWidget *widget, gpointer filesel)
    char *sel;
    struct stat statb;
 
-   jp_logf(JP_LOG_DEBUG, "cb_import\n");
+   jp_logf(JP_LOG_DEBUG, "import_gui.c:cb_import()\n");
    sel = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(widget));
    jp_logf(JP_LOG_DEBUG, "file selected [%s]\n", sel);
 

--- a/jp-pi-contact.h
+++ b/jp-pi-contact.h
@@ -28,6 +28,7 @@
 #define __JP_PI_CONTACT_H_
 
 #include "config.h"
+#include "pi-blob.h"
 #include <pi-contact.h>
 
 #define NUM_CONTACT_FIELDS  40

--- a/jpilot-dump.c
+++ b/jpilot-dump.c
@@ -56,6 +56,8 @@
 /* #define JDUMP_DEBUG 1 */
 
 /******************************* Global vars **********************************/
+int glob_sqlite = 0;	// just to keep the linker happy
+int glob_rc_file_write = 1;	// just to keep the linker happy
 /* dump switches */
 int  dumpD;
 int  dumpI;

--- a/jpilot-merge.c
+++ b/jpilot-merge.c
@@ -58,6 +58,8 @@
  * this code but must be instantiated for the code to compile.  
  * The same is true of the functions which are only used in GUI mode. */
 int pipe_to_parent = 0;
+int glob_sqlite = 0;	// just to keep the linker happy
+int glob_rc_file_write = 1;	// just to keep the linker happy
 pid_t jpilot_master_pid = -1;
 GtkWidget *glob_dialog;
 GtkWidget *glob_date_label;

--- a/jpilot-sync.c
+++ b/jpilot-sync.c
@@ -48,6 +48,8 @@ unsigned char skip_plugins;
  * The same is true of the functions which are only used in GUI mode. */
 pid_t jpilot_master_pid = -1;
 GtkWidget *glob_date_label;
+int glob_sqlite = 0;	// just to keep the linker happy
+int glob_rc_file_write = 1;	// just to keep the linker happy
 GtkWidget *glob_dialog;
 gint glob_date_timer_tag;
 

--- a/jpsqlite/Makefile.am
+++ b/jpsqlite/Makefile.am
@@ -1,0 +1,11 @@
+libdir = @libdir@/@PACKAGE@/plugins
+
+if MAKE_JPSQLITE
+
+lib_LTLIBRARIES = libjpsqlite.la
+libjpsqlite_la_SOURCES = jpsqlite.c
+libjpsqlite_la_CFLAGS = @PILOT_FLAGS@ @GTK_CFLAGS@ -I$(top_srcdir)
+libjpsqlite_la_LDFLAGS = -module -avoid-version
+libjpsqlite_la_LIBADD = @GTK_LIBS@ -lsqlite3
+
+endif

--- a/jpsqlite/jpsqlite.c
+++ b/jpsqlite/jpsqlite.c
@@ -1,0 +1,859 @@
+/* J-Pilot plugin for sqlite3
+   Write from pdb+pc3 records to single SQLite3 database.
+   Works for: Address, Datebook, Memo, ToDo, Expense
+   Elmar Klausmeier, 16-Apr-2020
+   Elmar Klausmeier, 28-Sep-2021: Changed to GTK3
+
+   License: GPL v2 (GNU General Public License)
+   https://www.gnu.org/licenses/old-licenses/gpl-2.0.html
+
+   Build with:
+   gcc `pkg-config -cflags-only-I gtk+-3.0` -I <J-Pilot src dir> -s -fPIC -shared jpsqlite.c -o libjpsqlite.so
+
+   Lib "-lsqlite3" no longer required, as it is part of GTK3/Tracker.
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <sqlite3.h>
+#include <errno.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <gtk/gtk.h>
+#include "log.h"
+#include "address.h"
+#include "calendar.h"
+#include "memo.h"
+#include "todo.h"
+#include <pi-expense.h>
+#include "libplugin.h"
+#include "stock_buttons.h"
+#include "i18n.h"
+#include "libsqlite.h"	// for checking global variable glob_sqlite
+#include "prefs.h"
+
+
+
+// Get bit 5 of x
+#define IS_PRIVATE(x)	((((x) & 0xF0) >> 4) & 0x01)
+// Run SQLite command/function x and store error text E
+#define CHK(x,E)	if ((sqlRet = x) != SQLITE_OK) { sqlErr=E; goto err; }
+#define CHKDONE(x,E)	if ((sqlRet = x) != SQLITE_DONE) { sqlErr=E; goto err; }
+
+
+
+static sqlite3 *db;	// file global database pointer
+static GtkWidget *copy_sqlite_button;
+static int connected = 0;	// Gtk signal handlers
+
+
+void plugin_version(int *major_version, int *minor_version) {
+	*major_version = 1;
+	*minor_version = 8;
+}
+
+
+
+int plugin_get_name(char *name, int len) {
+	strncpy(name,"SQLite3",len);
+	return EXIT_SUCCESS;
+}
+
+
+
+int plugin_get_help_name(char *name, int len) {
+	g_snprintf(name, len, _("About %s"), _("SQLite3"));
+	return EXIT_SUCCESS;
+}
+
+
+
+int plugin_help(char **text, int *width, int *height) {
+	*text = strdup(
+		"\n"
+		"SQLite3\n\n"
+		"Elmar Klausmeier, 28-Sep-2021\n"
+		"Elmar Klausmeier, 07-Nov-2022\n"
+		"https://eklausmeier.goip.de\n"
+		"\n");
+	*height = 0;
+	*width = 0;
+	return EXIT_SUCCESS;
+}
+
+
+
+int plugin_get_menu_name(char *name, int len) {
+	strncpy(name,glob_sqlite ? "SQLite3 disabled" : "SQLite3",len);
+	return EXIT_SUCCESS;
+}
+
+
+
+int plugin_exit_cleanup(void) {
+	int sqlRet = sqlite3_close(db);	// noop if db==NULL
+	if (sqlRet != SQLITE_OK) {
+		jp_logf(JP_LOG_FATAL,"Cannot close sqlite3 file, sqlRet=%d\n",sqlRet);
+		return EXIT_FAILURE;
+	}
+	return EXIT_SUCCESS;
+}
+
+
+
+sqlite3 *openSQLite(void) {	// return database handle
+	char dbName[FILENAME_MAX];	// path + file-name
+	char sqlFile[FILENAME_MAX];
+	FILE *fp;
+	char *p0;	// points to SQL string in jptables.sql
+	struct stat sqlFStat;
+	sqlite3 *d = NULL;
+	int sqlRet = 0;
+	char *sqlErr = "";
+
+	jp_get_home_file_name("jptables.db",dbName,FILENAME_MAX);
+	jp_logf(JP_LOG_DEBUG,"openSQLite(): dbName=%s\n",dbName);
+	if (sqlite3_open_v2(dbName,&d,SQLITE_OPEN_READWRITE,NULL) == SQLITE_OK)
+		return d;
+
+	// Now try to create new jptables.db by using SQL script
+	// in $HOME/.jpilot/plugins/jptables.sql
+	jp_get_home_file_name("plugins/jptables.sql",sqlFile,FILENAME_MAX);
+	jp_logf(JP_LOG_DEBUG,"openSQLite(): sqlFile=%s\n",sqlFile);
+	if ( stat(sqlFile,&sqlFStat) ) {
+		jp_logf(JP_LOG_FATAL,
+			"Cannot stat SQL file jptables.sql in plugins directory: %s\n",
+			strerror(errno));
+		return NULL;
+	}
+	if (sqlFStat.st_size == 0) {
+		jp_logf(JP_LOG_FATAL,"SQL file jptables.sql has no content\n");
+		return NULL;
+	}
+	if ((fp = fopen(sqlFile,"r")) == NULL) {
+		jp_logf(JP_LOG_FATAL,
+			"Cannot open SQL file jptables.sql in plugins directory: %s\n",
+			strerror(errno));
+		return NULL;
+	}
+	jp_logf(JP_LOG_DEBUG,"openSQLite(): jptables.sql size=%ld\n",
+		sqlFStat.st_size);
+	if ((p0 = malloc(sqlFStat.st_size + 4)) == NULL) {
+		jp_logf(JP_LOG_FATAL,
+			"Cannot cache jptables.sql: %s\n",
+			strerror(errno));
+		return NULL;
+	}
+	if (fread(p0,1,sqlFStat.st_size,fp) != sqlFStat.st_size) {
+		jp_logf(JP_LOG_FATAL,
+			"Cannot read jptables.sql: %s\n",
+			strerror(errno));
+		return NULL;
+	}
+	p0[sqlFStat.st_size] = '\0';
+	// Open and create db
+	jp_logf(JP_LOG_GUI,"\nCreating new SQLite3 database file %s. This may take approx. 20 seconds.\n\n",dbName);
+	CHK(sqlite3_open(dbName,&d),"IOP")
+	// Feed entire file content to SQLite3
+	CHK(sqlite3_exec(d,p0,NULL,NULL,NULL),"IEXC");
+
+	free(p0);
+	if (fclose(fp)) {
+		jp_logf(JP_LOG_FATAL,
+			"Cannot close jptables.sql: %s\n", strerror(errno));
+		return NULL;
+	}
+	jp_logf(JP_LOG_GUI,"SQLite3 database created successfully.\n");
+	return d;
+
+err:
+	jp_logf(JP_LOG_FATAL,"openSQLite(): SQLite3 ret=%d, error=%s, rolling back\n%s\n",
+		sqlRet, sqlErr, sqlite3_errmsg(d));
+	return NULL;
+}
+
+
+
+int plugin_search(const char *search_string, int case_sense, struct search_result **sr) {
+	sqlite3_stmt *dbpstmt = NULL;
+	char *srch;	// = % + search_string + %
+	struct search_result *prev_sr = NULL;
+	size_t len;
+	int sqlRet = 0;
+	char *sqlErr = "";
+	int nrecs;
+
+	// Search only if in debug-mode
+	if ( ! (glob_log_file_mask & JP_LOG_DEBUG) ) return 0;
+	jp_logf(JP_LOG_DEBUG,"\nIn plugin_search(): case_sense=%d, search_string=|%s|\n",
+		case_sense, search_string);
+	if (search_string[0] == '\0') return 0;
+	len = strlen(search_string);
+
+	if ((srch = malloc(len+4)) == NULL) return 0;
+	srch[0] = '%';	// start concating
+	strcpy(srch+1,search_string);
+	srch[len+1] = '%';
+	srch[len+2] = '\0';
+
+	if (db == NULL  &&  (db = openSQLite()) == NULL) {
+		free(srch);
+		return 0;
+	}
+
+	// SQLite3 LIKE is case insensitive by default
+	if (case_sense) {
+		CHK(sqlite3_exec(db,"PRAGMA case_sensitive_like=true",NULL,NULL,NULL),"SCT")
+	} else {
+		CHK(sqlite3_exec(db,"PRAGMA case_sensitive_like=false",NULL,NULL,NULL),"SCF")
+	}
+
+	CHK(sqlite3_prepare_v2(db,
+		"select Id, substr(coalesce(Lastname,Firstname,''),1,80) as Line "
+		"from Addr "
+		"where Lastname like :srch "
+		"or Firstname like :srch "
+		"or Phone1 like :srch "
+		"or Phone2 like :srch "
+		"or Phone3 like :srch "
+		"or Phone4 like :srch "
+		"or Phone5 like :srch "
+		"or Address like :srch "
+		"or City like :srch "
+		"or State like :srch "
+		"or Zip like :srch "
+		"or Custom1 like :srch "
+		"or Custom2 like :srch "
+		"or Custom3 like :srch "
+		"or Custom4 like :srch "
+		"or Note like :srch "
+		"union "
+		"select Id, substr(Begin || '  ' || coalesce(Description,''),1,80) as Line "
+		"from Datebook "
+		"where Description like :srch "
+		"or Note like :srch "
+		"union "
+		"select Id, substr(Text,1,80) as Line "
+		"from Memo "
+		"where Text like :srch "
+		"union "
+		"select Id, substr(Description,1,80) as Line "
+		"from ToDo "
+		"where Description like :srch "
+		"or Note like :srch "
+		"union "
+		"select Id, substr(coalesce(Date,'') || ' ' "
+		"    || coalesce(Amount,'') || coalesce(Vendor,'') "
+		"    || coalesce(Note,''),1,80) as Line "
+		"from Expense "
+		"where Amount like :srch "
+		"or Vendor like :srch "
+		"or City like :srch "
+		"or Attendees like :srch "
+		"or Note like :srch "
+		, -1, &dbpstmt, NULL), "SPRE")
+	CHK(sqlite3_bind_text(dbpstmt,1,srch,-1,SQLITE_STATIC),"SB1")
+	sqlErr = "SST";
+	for (nrecs=0; nrecs < 400; ++nrecs) {
+		sqlRet = sqlite3_step(dbpstmt);
+		if (sqlRet == SQLITE_DONE) break;
+		else if (sqlRet != SQLITE_ROW) goto err;
+		if ((*sr = malloc(sizeof(struct search_result))) == NULL)
+			goto err;
+		(*sr)->unique_id = sqlite3_column_int(dbpstmt,0);
+		(*sr)->line = strdup((const char*)sqlite3_column_text(dbpstmt,1));
+		(*sr)->next = prev_sr;
+		prev_sr = *sr;
+		jp_logf(JP_LOG_DEBUG,"\n\t%d: %s\n",
+			(*sr)->unique_id, (*sr)->line);
+	}
+
+	CHK(sqlite3_finalize(dbpstmt),"SFIN")
+	free(srch);
+	return nrecs;
+
+err:
+	free(srch);
+	jp_logf(JP_LOG_FATAL,"plugin_search(): SQLite3 ret=%d, error=%s, cannot search\n%s\n",
+		sqlRet, sqlErr, sqlite3_errmsg(db));
+	sqlite3_finalize(dbpstmt);
+	return 0;
+}
+
+
+
+//int plugin_pre_sync_pre_connect(void)
+static int copy_sqlite(void) {
+	struct AddressAppInfo ai;
+	AddressList *a;
+	CalendarEventList *c;
+	char begin[32], end[32], repeatEnd[32], *pRepeatEnd, due[32], date[32], prefLong[32], exceptionString[2048];
+	struct MemoAppInfo mi;
+	MemoList *m;
+	struct ToDoAppInfo tdi;
+	ToDoList *td;
+	struct ExpenseAppInfo ei;
+	struct Expense e;
+	unsigned char *buf;
+	int buf_size;
+	GList *explst;
+	buf_rec *br;
+	int nrecsA=0, nrecsAL=0, nrecsAC=0, nrecsPL=0, nrecsD=0;
+	int nrecsT=0, nrecsTC=0, nrecsM=0, nrecsMC=0, nrecsE=0, nrecsEC=0;
+	int i, r, total_records, offset, repeatForever;
+	sqlite3_stmt *dbpstmt = NULL;
+	int sqlRet = 0, errId;
+	char *sqlErr = "";
+
+
+	if (db == NULL  &&  (db = openSQLite()) == NULL)
+		return EXIT_FAILURE;
+	errId = -1;
+	CHK(sqlite3_exec(db,"BEGIN TRANSACTION",NULL,NULL,NULL),"BEGIN")
+	CHK(sqlite3_exec(db,
+		"delete from Addr; "
+		"delete from AddrLabel; "
+		"delete from AddrCategory; "
+		"delete from PhoneLabel; "
+		"delete from Datebook; "
+		"delete from ToDo; "
+		"delete from ToDoCategory; "
+		"delete from Memo; "
+		"delete from MemoCategory; "
+		"delete from Expense; "
+		"delete from ExpenseCategory; "
+		"delete from Pref; "
+		, NULL, NULL, NULL), "DEALL")
+
+
+	// Address
+	jp_logf(JP_LOG_DEBUG,"get_address_app_info()\n");
+	if ((r = get_address_app_info(&ai)) != 0) {
+		jp_logf(JP_LOG_DEBUG,"get_address_app_info() returned %d\n",r);
+		return EXIT_FAILURE;
+	}
+	jp_logf(JP_LOG_DEBUG,"\taddress labels\n");
+	errId = -1;
+	CHK(sqlite3_prepare_v2(db,
+		"insert into AddrLabel (Id, Label) "
+		"values (:Id, :Label)", -1, &dbpstmt, NULL), "ALPRE")
+	for (i=0; i<19; ++i) {
+		if (ai.labels[i][0] == '\0') continue;
+		jp_logf(JP_LOG_DEBUG,"\t\t%2d %s\n",i,ai.labels[i]);
+		++nrecsAL;
+		errId = i;
+		CHK(sqlite3_bind_int(dbpstmt,1,i),"ALB1")
+		CHK(sqlite3_bind_text(dbpstmt,2,ai.labels[i],-1,SQLITE_STATIC),"ALB2")
+		CHKDONE(sqlite3_step(dbpstmt),"ALST")
+		CHK(sqlite3_clear_bindings(dbpstmt),"ALCL")
+		CHK(sqlite3_reset(dbpstmt),"ALRST")
+	}
+	CHK(sqlite3_finalize(dbpstmt),"ALFIN")
+
+	errId = -1;
+	CHK(sqlite3_prepare_v2(db,
+		"insert into AddrCategory (Id, Label, InsertDate) "
+		"values (:Id, :Label, strftime('%Y-%m-%dT%H:%M:%S', 'now'))",
+		-1, &dbpstmt, NULL), "ACPRE")
+	jp_logf(JP_LOG_DEBUG,"\tAddress categories\n");
+	for (i=0; i<16; ++i) {
+		if (ai.category.name[i][0] == '\0') continue;
+		jp_logf(JP_LOG_DEBUG,"\t\t%2d %s\n",i,ai.category.name[i]);
+		++nrecsAC;
+		errId = i;
+		CHK(sqlite3_bind_int(dbpstmt,1,i),"ACB1")
+		CHK(sqlite3_bind_text(dbpstmt,2,ai.category.name[i],-1,SQLITE_STATIC),"ACB2")
+		CHKDONE(sqlite3_step(dbpstmt),"ACST")
+		CHK(sqlite3_clear_bindings(dbpstmt),"ACCL")
+		CHK(sqlite3_reset(dbpstmt),"ACRST")
+	}
+	CHK(sqlite3_finalize(dbpstmt),"ACFIN")
+
+	errId = -1;
+	CHK(sqlite3_prepare_v2(db,
+		"insert into PhoneLabel (Id, Label) "
+		"values (:Id, :Label)", -1, &dbpstmt, NULL), "PLPRE")
+	for (i=0; i<8; ++i) {
+		if (ai.phoneLabels[i][0] == '\0') continue;
+		jp_logf(JP_LOG_DEBUG,"\t\t%2d %s\n",i,ai.phoneLabels[i]);
+		++nrecsPL;
+		errId = i;
+		CHK(sqlite3_bind_int(dbpstmt,1,i),"PLB1")
+		CHK(sqlite3_bind_text(dbpstmt,2,ai.phoneLabels[i],-1,SQLITE_STATIC),"PLB2")
+		CHKDONE(sqlite3_step(dbpstmt),"PLST")
+		CHK(sqlite3_clear_bindings(dbpstmt),"PLCL")
+		CHK(sqlite3_reset(dbpstmt),"PLRST")
+	}
+	CHK(sqlite3_finalize(dbpstmt),"PLFIN")
+
+	r = get_addresses(&a, SORT_ASCENDING);
+	jp_logf(JP_LOG_DEBUG,"get_addresses() returned %d records\n", r);
+	errId = -1;
+	CHK(sqlite3_prepare_v2(db,
+		"insert into Addr ("
+		"    Id, Category, Private, showPhone,"	// 1
+		"    Lastname, Firstname, Title, Company,"	// 5
+		"    PhoneLabel1, PhoneLabel2, PhoneLabel3,"	// 9
+		"    PhoneLabel4, PhoneLabel5,"		// 12
+		"    Phone1, Phone2, Phone3, Phone4, Phone5,"	// 14
+		"    Address, City, State, Zip, Country,"	// 19
+		"    Custom1, Custom2, Custom3, Custom4,"	// 24
+		"    Note, InsertDate"					// 28
+		") values ("
+		"    :Id, :Category, :Private, :showPhone,"
+		"    :Lastname, :Firstname, :Title, :Company,"
+		"    :PhoneLabel1, :PhoneLabel2, :PhoneLabel3,"
+		"    :PhoneLabel4, :PhoneLabel5,"
+		"    :Phone1, :Phone2, :Phone3, :Phone4, :Phone5,"
+		"    :Address, :City, :State, :Zip, :Country,"
+		"    :Custom1, :Custom2, :Custom3, :Custom4,"
+		"    :Note, strftime('%Y-%m-%dT%H:%M:%S', 'now')"
+		")",
+		-1, &dbpstmt, NULL), "APRE")
+
+	for (; a; a=a->next) {
+		if (a->maddr.unique_id == 1693099) {
+			jp_logf(JP_LOG_DEBUG,"\t%d, %d: %s\n",
+				a->maddr.unique_id,
+				a->maddr.rt,
+				a->maddr.addr.entry[entryLastname]);
+		}
+		//if (nrecsA < 10)
+			jp_logf(JP_LOG_DEBUG,"\t%d, %9u, rt=%d, %s: %s, %s\n",
+				a->app_type,
+				a->maddr.unique_id,
+				a->maddr.rt,
+				ai.category.name[a->maddr.attrib & 0x0F],
+				a->maddr.addr.entry[entryLastname],
+				a->maddr.addr.entry[entryFirstname]);
+		if (a->maddr.rt != PALM_REC
+		&&  a->maddr.rt != NEW_PC_REC
+		&&  a->maddr.rt != REPLACEMENT_PALM_REC)
+			continue;
+		++nrecsA;
+		errId = a->maddr.unique_id;
+		CHK(sqlite3_bind_int(dbpstmt,1,a->maddr.unique_id),"AB1")
+		CHK(sqlite3_bind_int(dbpstmt,2,a->maddr.attrib & 0x0F),"AB2")
+		CHK(sqlite3_bind_int(dbpstmt,3,IS_PRIVATE(a->maddr.attrib)),"AB3")
+		CHK(sqlite3_bind_int(dbpstmt,4,a->maddr.addr.showPhone),"AB4")
+		CHK(sqlite3_bind_text(dbpstmt,5,a->maddr.addr.entry[entryLastname],-1,SQLITE_STATIC),"AB5")
+		CHK(sqlite3_bind_text(dbpstmt,6,a->maddr.addr.entry[entryFirstname],-1,SQLITE_STATIC),"AB6")
+		CHK(sqlite3_bind_text(dbpstmt,7,a->maddr.addr.entry[entryTitle],-1,SQLITE_STATIC),"AB7")
+		CHK(sqlite3_bind_text(dbpstmt,8,a->maddr.addr.entry[entryCompany],-1,SQLITE_STATIC),"AB8")
+		CHK(sqlite3_bind_int(dbpstmt,9,a->maddr.addr.phoneLabel[0]),"AB9")
+		CHK(sqlite3_bind_int(dbpstmt,10,a->maddr.addr.phoneLabel[1]),"AB10")
+		CHK(sqlite3_bind_int(dbpstmt,11,a->maddr.addr.phoneLabel[2]),"AB11")
+		CHK(sqlite3_bind_int(dbpstmt,12,a->maddr.addr.phoneLabel[3]),"AB12")
+		CHK(sqlite3_bind_int(dbpstmt,13,a->maddr.addr.phoneLabel[4]),"AB13")
+		CHK(sqlite3_bind_text(dbpstmt,14,a->maddr.addr.entry[entryPhone1],-1,SQLITE_STATIC),"AB14")
+		CHK(sqlite3_bind_text(dbpstmt,15,a->maddr.addr.entry[entryPhone2],-1,SQLITE_STATIC),"AB15")
+		CHK(sqlite3_bind_text(dbpstmt,16,a->maddr.addr.entry[entryPhone3],-1,SQLITE_STATIC),"AB16")
+		CHK(sqlite3_bind_text(dbpstmt,17,a->maddr.addr.entry[entryPhone4],-1,SQLITE_STATIC),"AB17")
+		CHK(sqlite3_bind_text(dbpstmt,18,a->maddr.addr.entry[entryPhone5],-1,SQLITE_STATIC),"AB18")
+		CHK(sqlite3_bind_text(dbpstmt,19,a->maddr.addr.entry[entryAddress],-1,SQLITE_STATIC),"AB19")
+		CHK(sqlite3_bind_text(dbpstmt,20,a->maddr.addr.entry[entryCity],-1,SQLITE_STATIC),"AB20")
+		CHK(sqlite3_bind_text(dbpstmt,21,a->maddr.addr.entry[entryState],-1,SQLITE_STATIC),"AB21")
+		CHK(sqlite3_bind_text(dbpstmt,22,a->maddr.addr.entry[entryZip],-1,SQLITE_STATIC),"AB22")
+		CHK(sqlite3_bind_text(dbpstmt,23,a->maddr.addr.entry[entryCountry],-1,SQLITE_STATIC),"AB23")
+		CHK(sqlite3_bind_text(dbpstmt,24,a->maddr.addr.entry[entryCustom1],-1,SQLITE_STATIC),"AB24")
+		CHK(sqlite3_bind_text(dbpstmt,25,a->maddr.addr.entry[entryCustom2],-1,SQLITE_STATIC),"AB25")
+		CHK(sqlite3_bind_text(dbpstmt,26,a->maddr.addr.entry[entryCustom3],-1,SQLITE_STATIC),"AB26")
+		CHK(sqlite3_bind_text(dbpstmt,27,a->maddr.addr.entry[entryCustom4],-1,SQLITE_STATIC),"AB27")
+		CHK(sqlite3_bind_text(dbpstmt,28,a->maddr.addr.entry[entryNote],-1,SQLITE_STATIC),"AB28")
+		CHKDONE(sqlite3_step(dbpstmt),"AST")
+		CHK(sqlite3_clear_bindings(dbpstmt),"ACL")
+		CHK(sqlite3_reset(dbpstmt),"ARST")
+		if (nrecsA > 29500) break;	// runaway?
+	}
+	CHK(sqlite3_finalize(dbpstmt),"AFIN")
+	jp_logf(JP_LOG_DEBUG,"%d address records in list\n", nrecsA);
+
+
+	// Datebook
+	r = get_days_calendar_events(&c, NULL, CATEGORY_ALL, &total_records);
+	jp_logf(JP_LOG_DEBUG,"get_days_calendar_events() returned %d\n", r);
+	errId = -1;
+	CHK(sqlite3_prepare_v2(db,
+		"insert into Datebook ("
+		"    Id, Private, Timeless, Begin, End,"	// 1
+		"    Alarm, Advance, AdvanceUnit, RepeatType,"	// 6
+		"    RepeatForever, RepeatEnd, RepeatFreq,"	// 10
+		"    RepeatDay,"				// 13
+		"    RepeatDaySu, RepeatDayMo, RepeatDayTu,"	// 14
+		"    RepeatDayWe, RepeatDayTh, RepeatDayFr,"	// 17
+		"    RepeatDaySa, Exceptions, Exception,"		// 20
+		"    Description, Note, InsertDate"		// 23
+		") values ("
+		"    :Id, :Private, :Timeless, :Begin, :End,"
+		"    :Alarm, :Advance, :AdvanceUnit, :RepeatType,"
+		"    :RepeatForever, :RepeatEnd, :RepeatFreq,"
+		"    :RepeatDay,"
+		"    :RepeatDaySu, :RepeatDayMo, :RepeatDayTu,"
+		"    :RepeatDayWe, :RepeatDayTh, :RepeatDayFr,"
+		"    :RepeatDaySa, :Exceptions, :Exception,"
+		"    :Description, :Note, strftime('%Y-%m-%dT%H:%M:%S', 'now')"
+		")",
+		-1, &dbpstmt, NULL), "DPRE")
+	for (; c; c=c->next) {
+		if (nrecsD < 10)
+			jp_logf(JP_LOG_DEBUG,"\t%d rt=%d %s <<%s>>\n",
+				c->mcale.unique_id,
+				c->mcale.rt,
+				c->mcale.cale.description,
+				c->mcale.cale.note);
+		if (c->mcale.rt != PALM_REC
+		&&  c->mcale.rt != NEW_PC_REC
+		&&  c->mcale.rt != REPLACEMENT_PALM_REC)
+			continue;
+		++nrecsD;
+		errId = c->mcale.unique_id;
+		strftime(begin,32,"%FT%R",&c->mcale.cale.begin);
+		strftime(end,32,"%FT%R",&c->mcale.cale.end);
+		// Data cleansing
+		if (c->mcale.cale.repeatEnd.tm_year < 2
+		||  c->mcale.cale.repeatEnd.tm_year > 2050)
+			pRepeatEnd = NULL;
+		else
+			strftime(pRepeatEnd=repeatEnd,32,"%F",&c->mcale.cale.repeatEnd);
+		CHK(sqlite3_bind_int(dbpstmt,1,c->mcale.unique_id),"DB1")
+		CHK(sqlite3_bind_int(dbpstmt,2,IS_PRIVATE(c->mcale.attrib)),"DB2")
+		CHK(sqlite3_bind_int(dbpstmt,3,c->mcale.cale.event),"DB3")
+		CHK(sqlite3_bind_text(dbpstmt,4,begin,-1,SQLITE_STATIC),"DB4")
+		CHK(sqlite3_bind_text(dbpstmt,5,end,-1,SQLITE_STATIC),"DB5")
+		CHK(sqlite3_bind_int(dbpstmt,6,c->mcale.cale.alarm),"DB6")
+		CHK(sqlite3_bind_int(dbpstmt,7,c->mcale.cale.advance),"DB7")
+		CHK(sqlite3_bind_int(dbpstmt,8,c->mcale.cale.advanceUnits),"DB8")
+		CHK(sqlite3_bind_int(dbpstmt,9,c->mcale.cale.repeatType),"DB9")
+		// 1 - (c->mcale.cale.repeatForever & 0x01)
+		repeatForever = c->mcale.cale.repeatForever & 0x01;
+		if (c->mcale.cale.repeatFrequency == 0 && c->mcale.cale.repeatDay == 0 && c->mcale.cale.repeatDays[0] == 0
+		&& c->mcale.cale.repeatDays[1] == 0 && c->mcale.cale.repeatDays[2] == 0 && c->mcale.cale.repeatDays[3] == 0
+		&& c->mcale.cale.repeatDays[4] == 0 && c->mcale.cale.repeatDays[5] == 0 && c->mcale.cale.repeatDays[6] == 0
+		&& pRepeatEnd == NULL)
+			repeatForever = 1;
+		CHK(sqlite3_bind_int(dbpstmt,10,repeatForever),"DB10")
+		CHK(sqlite3_bind_text(dbpstmt,11,pRepeatEnd,-1,SQLITE_STATIC),"DB11")
+		CHK(sqlite3_bind_int(dbpstmt,12,c->mcale.cale.repeatFrequency),"DB12")
+		CHK(sqlite3_bind_int(dbpstmt,13,c->mcale.cale.repeatDay),"DB13")
+		CHK(sqlite3_bind_int(dbpstmt,14,c->mcale.cale.repeatDays[0]),"DB14")
+		CHK(sqlite3_bind_int(dbpstmt,15,c->mcale.cale.repeatDays[1]),"DB15")
+		CHK(sqlite3_bind_int(dbpstmt,16,c->mcale.cale.repeatDays[2]),"DB16")
+		CHK(sqlite3_bind_int(dbpstmt,17,c->mcale.cale.repeatDays[3]),"DB17")
+		CHK(sqlite3_bind_int(dbpstmt,18,c->mcale.cale.repeatDays[4]),"DB18")
+		CHK(sqlite3_bind_int(dbpstmt,19,c->mcale.cale.repeatDays[5]),"DB19")
+		CHK(sqlite3_bind_int(dbpstmt,20,c->mcale.cale.repeatDays[6]),"DB20")
+		CHK(sqlite3_bind_int(dbpstmt,21,c->mcale.cale.exceptions),"DB21")
+		if (c->mcale.cale.exceptions * 11 > sizeof(exceptionString)) {
+			strcpy(exceptionString,"Too many exceptions");
+		} else {
+			for (i=0,offset=0; i<c->mcale.cale.exceptions; ++i,offset+=11) {
+				strftime(exceptionString+offset,11,"%F",c->mcale.cale.exception+i);
+				if (i > 0) exceptionString[offset-1] = ' ';	// change previous '\0' to space
+			}
+		}
+		CHK(sqlite3_bind_text(dbpstmt,22,c->mcale.cale.exceptions ? exceptionString : NULL,-1,SQLITE_STATIC),"DB22")
+		CHK(sqlite3_bind_text(dbpstmt,23,c->mcale.cale.description,-1,SQLITE_STATIC),"DB23")
+		CHK(sqlite3_bind_text(dbpstmt,24,c->mcale.cale.note,-1,SQLITE_STATIC),"DB24")
+		CHKDONE(sqlite3_step(dbpstmt),"DST")
+		CHK(sqlite3_clear_bindings(dbpstmt),"DCL")
+		CHK(sqlite3_reset(dbpstmt),"DRST")
+		//if (nrecsD > 350000) break;	// safety check
+	}
+	CHK(sqlite3_finalize(dbpstmt),"DFIN")
+	jp_logf(JP_LOG_DEBUG,"%d calendar records in list\n", nrecsD);
+
+
+	// Memo
+	if ((r = get_memo_app_info(&mi)) != 0) {
+		jp_logf(JP_LOG_DEBUG,"get_memo_app_info() returned %d\n",r);
+		return EXIT_FAILURE;
+	}
+	CHK(sqlite3_prepare_v2(db,
+		"insert into MemoCategory (Id, Label, InsertDate) "
+		"values (:Id, :Label, strftime('%Y-%m-%dT%H:%M:%S', 'now'))",
+		-1, &dbpstmt, NULL), "MCPRE")
+	for (i=0; i<16; ++i) {
+		if (mi.category.name[i][0] == '\0') continue;
+		jp_logf(JP_LOG_DEBUG,"\t\t%2d %s\n",i,mi.category.name[i]);
+		++nrecsMC;
+		errId = i;
+		CHK(sqlite3_bind_int(dbpstmt,1,i),"MCB1")
+		CHK(sqlite3_bind_text(dbpstmt,2,mi.category.name[i],-1,SQLITE_STATIC),"MCB2")
+		CHKDONE(sqlite3_step(dbpstmt),"MCST")
+		CHK(sqlite3_clear_bindings(dbpstmt),"MCCL")
+		CHK(sqlite3_reset(dbpstmt),"MCRST")
+	}
+	CHK(sqlite3_finalize(dbpstmt),"MCFIN")
+
+	errId = -1;
+	CHK(sqlite3_prepare_v2(db,
+		"insert into Memo ("
+		"    Id, Category, Private, Text, InsertDate"
+		") values ("
+		"    :Id, :Category, :Private, :Text, strftime('%Y-%m-%dT%H:%M:%S', 'now')"
+		")",
+		-1, &dbpstmt, NULL), "MPRE")
+	r = get_memos(&m,SORT_ASCENDING);	//,0,0,1,CATEGORY_ALL);
+	jp_logf(JP_LOG_DEBUG,"get_memos() returned %d\n", r);
+	for (; m; m=m->next) {
+		/* * *
+		if (nrecsM < 10)
+			jp_logf(JP_LOG_DEBUG,"\t%d rt=%d (%s) %.60s\n",
+				m->mmemo.unique_id,
+				m->mmemo.rt,
+				mi.category.name[m->mmemo.attrib & 0x0F],
+				m->mmemo.memo.text);
+		* * */
+		if (m->mmemo.rt != PALM_REC
+		&&  m->mmemo.rt != NEW_PC_REC
+		&&  m->mmemo.rt != REPLACEMENT_PALM_REC)
+			continue;
+		++nrecsM;
+		errId = m->mmemo.unique_id;
+		CHK(sqlite3_bind_int(dbpstmt,1,m->mmemo.unique_id),"MB1")
+		CHK(sqlite3_bind_int(dbpstmt,2,m->mmemo.attrib & 0x0F),"MB2")
+		CHK(sqlite3_bind_int(dbpstmt,3,IS_PRIVATE(m->mmemo.attrib)),"MB3")
+		CHK(sqlite3_bind_text(dbpstmt,4,m->mmemo.memo.text,-1,SQLITE_STATIC),"MB4")
+		CHKDONE(sqlite3_step(dbpstmt),"MST")
+		CHK(sqlite3_clear_bindings(dbpstmt),"MCL")
+		CHK(sqlite3_reset(dbpstmt),"MRST")
+		//if (nrecsM > 29500) break;	// runaway?
+	}
+	CHK(sqlite3_finalize(dbpstmt),"MFIN")
+	jp_logf(JP_LOG_DEBUG,"%d memo records in list\n", nrecsM);
+
+
+	// ToDo
+	if ((r = get_todo_app_info(&tdi)) != 0) {
+		jp_logf(JP_LOG_DEBUG,"get_todo_app_info() returned %d\n",r);
+		return EXIT_FAILURE;
+	}
+	errId = -1;
+	CHK(sqlite3_prepare_v2(db,
+		"insert into ToDoCategory (Id, Label, InsertDate) "
+		"values (:Id, :Label, strftime('%Y-%m-%dT%H:%M:%S', 'now'))",
+		-1, &dbpstmt, NULL),"TCPRE")
+	for (i=0; i<16; ++i) {
+		if (tdi.category.name[i][0] == '\0') continue;
+		jp_logf(JP_LOG_DEBUG,"\t\t%2d %s\n",i,tdi.category.name[i]);
+		++nrecsTC;
+		errId = i;
+		CHK(sqlite3_bind_int(dbpstmt,1,i),"TCB1")
+		CHK(sqlite3_bind_text(dbpstmt,2,tdi.category.name[i],-1,SQLITE_STATIC),"TCB2")
+		CHKDONE(sqlite3_step(dbpstmt),"TCST")
+		CHK(sqlite3_clear_bindings(dbpstmt),"TCCL")
+		CHK(sqlite3_reset(dbpstmt),"TCRST")
+	}
+	CHK(sqlite3_finalize(dbpstmt),"TCFIN")
+
+	errId = -1;
+	CHK(sqlite3_prepare_v2(db,
+		"insert into ToDo ("
+		"    Id, Category, Private, Indefinite,"	// 1
+		"    Due, Priority, Complete,"			// 5
+		"    Description, Note, InsertDate"		// 8
+		") values ("
+		"    :Id, :Category, :Private, :Indefinite, "
+		"    :Due, :Priority, :Complete, "
+		"    :Description, :Note, strftime('%Y-%m-%dT%H:%M:%S', 'now')"
+		")",
+		-1, &dbpstmt, NULL),"TPRE")
+	r = get_todos(&td,SORT_ASCENDING);
+	jp_logf(JP_LOG_DEBUG,"get_todos() returned %d\n", r);
+	for (; td; td=td->next) {
+		if (nrecsT < 10)
+			jp_logf(JP_LOG_DEBUG,"\t%d rt=%d (%s) %.60s\n",
+				td->mtodo.unique_id,
+				td->mtodo.rt,
+				tdi.category.name[td->mtodo.attrib & 0x0F],
+				td->mtodo.todo.description);
+		if (td->mtodo.rt != PALM_REC
+		&&  td->mtodo.rt != NEW_PC_REC
+		&&  td->mtodo.rt != REPLACEMENT_PALM_REC)
+			continue;
+		++nrecsT;
+		errId = td->mtodo.unique_id;
+		strftime(due,32,"%F",&td->mtodo.todo.due);
+		CHK(sqlite3_bind_int(dbpstmt,1,td->mtodo.unique_id),"TB1")
+		CHK(sqlite3_bind_int(dbpstmt,2,td->mtodo.attrib & 0x0F),"TB2")
+		CHK(sqlite3_bind_int(dbpstmt,3,IS_PRIVATE(td->mtodo.attrib)),"TB3")
+		CHK(sqlite3_bind_int(dbpstmt,4,td->mtodo.todo.indefinite),"TB4")
+		CHK(sqlite3_bind_text(dbpstmt,5,due,-1,SQLITE_STATIC),"TB5")
+		CHK(sqlite3_bind_int(dbpstmt,6,td->mtodo.todo.priority),"TB6")
+		CHK(sqlite3_bind_int(dbpstmt,7,td->mtodo.todo.complete),"TB7")
+		CHK(sqlite3_bind_text(dbpstmt,8,td->mtodo.todo.description,-1,SQLITE_STATIC),"TB8")
+		CHK(sqlite3_bind_text(dbpstmt,9,td->mtodo.todo.note,-1,SQLITE_STATIC),"TB9")
+		CHKDONE(sqlite3_step(dbpstmt),"TST")
+		CHK(sqlite3_clear_bindings(dbpstmt),"TCL")
+		CHK(sqlite3_reset(dbpstmt),"TRST")
+		//if (nrecsT > 29500) break;	// runaway?
+	}
+	CHK(sqlite3_finalize(dbpstmt),"TFIN")
+	jp_logf(JP_LOG_DEBUG,"%d to-do records in list\n", nrecsT);
+
+
+	// Expense
+	// Below modeled after make_menus() in Expense/expense.c
+	jp_get_app_info("ExpenseDB", &buf, &buf_size);
+	unpack_ExpenseAppInfo(&ei, buf, buf_size);
+	if (buf) free(buf);
+	errId = -1;
+	CHK(sqlite3_prepare_v2(db,
+		"insert into ExpenseCategory (Id, Label,InsertDate) "
+		"values (:Id, :Label, strftime('%Y-%m-%dT%H:%M:%S', 'now'))",
+		-1, &dbpstmt, NULL), "ECPRE")
+	jp_logf(JP_LOG_DEBUG,"\tExpense categories\n");
+	for (i=0; i<16; ++i) {
+		if (ei.category.name[i][0] == '\0') continue;
+		jp_logf(JP_LOG_DEBUG,"\t\t%2d %s\n",i,ei.category.name[i]);
+		++nrecsEC;
+		errId = i;
+		CHK(sqlite3_bind_int(dbpstmt,1,i),"ExpCatB1")
+		CHK(sqlite3_bind_text(dbpstmt,2,ei.category.name[i],-1,SQLITE_STATIC),"ExpCatB2")
+		CHKDONE(sqlite3_step(dbpstmt),"ExpCatST")
+		CHK(sqlite3_clear_bindings(dbpstmt),"ExpCatCL")
+		CHK(sqlite3_reset(dbpstmt),"ExpCatRST")
+	}
+	CHK(sqlite3_finalize(dbpstmt),"ExpCatFIN")
+
+	// Below modeled after display_records() in Expense/expense.c
+	r = jp_read_DB_files("ExpenseDB", &explst);
+	jp_logf(JP_LOG_DEBUG,"jp_read_DB_file() for ExpenseDB returned %d\n", r);
+	errId = -1;
+	CHK(sqlite3_prepare_v2(db,
+		"insert into Expense ("
+		"    Id, Category, Date, Type, Payment,"	// 1
+		"    Currency, Amount, Vendor, City,"		// 6
+		"    Attendees, Note, InsertDate"			// 10
+		") values ("
+		"    :Id, :Category, :Date, :Type, :Payment, "
+		"    :Currency, :Amount, :Vendor, :City, "
+		"    :Attendees, :Note, strftime('%Y-%m-%dT%H:%M:%S', 'now')"
+		")",
+		-1, &dbpstmt, NULL), "ExpPRE")
+	for (; explst; explst=explst->next) {
+		if ((br = explst->data) == NULL) continue;
+		if (br->rt != PALM_REC
+		&&  br->rt != NEW_PC_REC
+		&&  br->rt != REPLACEMENT_PALM_REC)
+			continue;
+		unpack_Expense(&e,br->buf,br->size);
+		if (nrecsE < 10)
+			jp_logf(JP_LOG_DEBUG,"\t%d rt=%d (%s) %.60s\n",
+				br->unique_id,
+				br->rt,
+				ei.category.name[br->attrib & 0x0F],
+				e.vendor);
+		++nrecsE;
+		errId = br->unique_id;
+		strftime(date,32,"%F",&(e.date));
+		CHK(sqlite3_bind_int(dbpstmt,1,br->unique_id),"ExpB1")
+		CHK(sqlite3_bind_int(dbpstmt,2,br->attrib & 0x0F),"ExpB2")
+		CHK(sqlite3_bind_text(dbpstmt,3,date,-1,SQLITE_STATIC),"EB5")
+		CHK(sqlite3_bind_int(dbpstmt,4,e.type),"ExpB4")
+		CHK(sqlite3_bind_int(dbpstmt,5,e.payment),"ExpB5")
+		CHK(sqlite3_bind_int(dbpstmt,6,e.currency),"ExpB6")
+		CHK(sqlite3_bind_text(dbpstmt,7,e.amount,-1,SQLITE_STATIC),"ExpB7")
+		CHK(sqlite3_bind_text(dbpstmt,8,e.vendor,-1,SQLITE_STATIC),"ExpB8")
+		CHK(sqlite3_bind_text(dbpstmt,9,e.city,-1,SQLITE_STATIC),"ExpB9")
+		CHK(sqlite3_bind_text(dbpstmt,10,e.attendees,-1,SQLITE_STATIC),"ExpB10")
+		CHK(sqlite3_bind_text(dbpstmt,11,e.note,-1,SQLITE_STATIC),"ExpB11")
+		CHKDONE(sqlite3_step(dbpstmt),"ExpST")
+		CHK(sqlite3_clear_bindings(dbpstmt),"ExpCL")
+		CHK(sqlite3_reset(dbpstmt),"ExpRST")
+		//if (nrecsE > 29500) break;	// runaway?
+	}
+	CHK(sqlite3_finalize(dbpstmt),"ExpFIN")
+	jp_logf(JP_LOG_DEBUG,"%d expense records in list\n", nrecsE);
+	jp_free_DB_records(&explst);
+
+	// Preferences
+	CHK(sqlite3_prepare_v2(db,
+		"insert into Pref ("
+		"    Id, Name, Usertype, Filetype, iValue, sValue, InsertDate"
+		") values ("
+		"    :Id, :Name, :Usertype, :Filetype, :iValue, :sValue, strftime('%Y-%m-%dT%H:%M:%S', 'now'))",
+		-1, &dbpstmt, NULL), "PrefPRE")
+	for (i=0; i<NUM_PREFS; i++) {
+		CHK(sqlite3_bind_int(dbpstmt,1,i),"PrefB1")
+		CHK(sqlite3_bind_text(dbpstmt,2,glob_prefs[i].name,-1,SQLITE_STATIC),"PrefB2")
+		CHK(sqlite3_bind_text(dbpstmt,3,glob_prefs[i].usertype == 1 ? "int" : "char",-1,SQLITE_STATIC),"PrefB3")
+		CHK(sqlite3_bind_text(dbpstmt,4,glob_prefs[i].filetype == 1 ? "int" : "char",-1,SQLITE_STATIC),"PrefB4")
+		CHK(sqlite3_bind_int(dbpstmt,5,glob_prefs[i].ivalue),"PrefB5")
+		CHK(sqlite3_bind_text(dbpstmt,6,glob_prefs[i].svalue,-1,SQLITE_STATIC),"PrefB6")
+		CHKDONE(sqlite3_step(dbpstmt),"PrefST")
+		CHK(sqlite3_clear_bindings(dbpstmt),"PrefCL")
+		CHK(sqlite3_reset(dbpstmt),"PrefRST")
+	}
+	CHK(sqlite3_finalize(dbpstmt),"PrefFIN")
+	jp_logf(JP_LOG_DEBUG,"%d Pref records in array\n", i);
+
+	CHK(sqlite3_exec(db,"END TRANSACTION",NULL,NULL,NULL),"END")
+	jp_logf(JP_LOG_GUI,"Finished SQLite3 transaction:\n"
+		"\t%8d inserted into Addr\n"
+		"\t%8d inserted into AddrLabel\n"
+		"\t%8d inserted into AddrCategory\n"
+		"\t%8d inserted into PhoneLabel\n"
+		"\t%8d inserted into Datebook\n"
+		"\t%8d inserted into ToDo\n"
+		"\t%8d inserted into ToDoCategory\n"
+		"\t%8d inserted into Memo\n"
+		"\t%8d inserted into MemoCategory\n"
+		"\t%8d inserted into Expense\n"
+		"\t%8d inserted into ExpenseCategory\n"
+		"\t%8d inserted into Pref\n"
+		, nrecsA, nrecsAL, nrecsAC, nrecsPL, nrecsD
+		, nrecsT, nrecsTC, nrecsM, nrecsMC, nrecsE, nrecsEC, NUM_PREFS
+	);
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"SQLite3 ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db));
+	sqlite3_finalize(dbpstmt);
+	sqlite3_exec(db,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+static void cb_copy_sqlite(GtkWidget *widget, gpointer data) {
+	copy_sqlite();
+}
+
+
+
+int plugin_gui(GtkWidget *vbox, GtkWidget *hbox, unsigned int unique_id) {
+	jp_logf(JP_LOG_DEBUG,"SQLite3 plugin_gui(): unique_id=%d\n",unique_id);
+
+	if (!glob_sqlite) {
+		copy_sqlite_button = gtk_button_new_with_label("SQL");
+		gtk_box_pack_start(GTK_BOX(vbox),copy_sqlite_button,TRUE,TRUE,0);
+		if (connected == 0) {
+			g_signal_connect(G_OBJECT(copy_sqlite_button),
+				"clicked",
+				G_CALLBACK(cb_copy_sqlite), NULL);
+			connected = 1;
+		}
+		gtk_widget_show_all(vbox);
+	}
+
+	return EXIT_SUCCESS;
+}
+
+
+
+int plugin_gui_cleanup(void) {
+	if (connected == 1) {
+		g_signal_handlers_disconnect_by_func(
+			G_OBJECT(copy_sqlite_button),
+			G_CALLBACK(cb_copy_sqlite), NULL);
+		connected = 0;
+	}
+	return EXIT_SUCCESS;
+}
+
+
+

--- a/jpsqlite/jptables.sql
+++ b/jpsqlite/jptables.sql
@@ -1,0 +1,344 @@
+--
+-- Create SQLite3 database tables for J-Pilot plugin.
+--
+-- SQLite3 table names and column names are case insensitive by default.
+-- SQLite3 uses type affinity and not rigid types.
+--
+-- Elmar Klausmeier, 17-Apr-2020
+-- Elmar Klausmeier, 31-Oct-2022: exceptions in Datebook
+-- Elmar Klausmeier, Nov-2022: added Pref + Alarms tables, InertDate+UpdateDate to various tables
+
+
+-- By default SQLite3 does not enforce foreign key constraints
+PRAGMA foreign_keys = ON;
+
+
+-- Drop all tables
+drop table if exists Addr;
+drop table if exists AddrLabel;
+drop table if exists AddrCategory;
+drop table if exists PhoneLabel;
+drop table if exists Datebook;
+drop table if exists ToDo;
+drop table if exists ToDoCategory;
+drop table if exists Memo;
+drop table if exists Expense;
+drop table if exists MemoCategory;
+drop table if exists ExpenseCategory;
+drop table if exists ExpenseType;
+drop table if exists ExpensePayment;
+
+
+
+-- Labels for address columns
+create table AddrLabel (
+	Id            int primary key,
+	Label         text
+);
+insert into AddrLabel (Id,Label) values (0,'Last name');
+insert into AddrLabel (Id,Label) values (1,'First name');
+insert into AddrLabel (Id,Label) values (2,'Company');
+insert into AddrLabel (Id,Label) values (3,'Work');
+insert into AddrLabel (Id,Label) values (4,'Home');
+insert into AddrLabel (Id,Label) values (5,'Fax');
+insert into AddrLabel (Id,Label) values (6,'Other');
+insert into AddrLabel (Id,Label) values (7,'E-mail');
+insert into AddrLabel (Id,Label) values (8,'Addr(W)');
+insert into AddrLabel (Id,Label) values (9,'City');
+insert into AddrLabel (Id,Label) values (10,'State');
+insert into AddrLabel (Id,Label) values (11,'Zip Code');
+insert into AddrLabel (Id,Label) values (12,'Country');
+insert into AddrLabel (Id,Label) values (13,'Title');
+insert into AddrLabel (Id,Label) values (14,'User-Id');
+insert into AddrLabel (Id,Label) values (15,'Custom 2');
+insert into AddrLabel (Id,Label) values (16,'Birthday');
+insert into AddrLabel (Id,Label) values (17,'Custom 4');
+insert into AddrLabel (Id,Label) values (18,'Note');
+
+
+-- Labels for address categories, like 'Business', 'Travel', etc.
+create table AddrCategory (
+	Id            int primary key,
+	Label         text,
+	InsertDate    text,            -- first insertion date in format YYYY-MM-DDTHH:MM
+	UpdateDate    text             -- latest update date in format YYYY-MM-DDTHH:MM
+);
+insert into AddrCategory (Id,Label) values (0,'Unfiled');
+
+
+-- Labels for address phone entries, like 'Work', 'Mobile', etc.
+create table PhoneLabel (
+	Id            int primary key,
+	Label         text
+);
+insert into PhoneLabel (Id,Label) values (0,'Work');
+insert into PhoneLabel (Id,Label) values (1,'Home');
+insert into PhoneLabel (Id,Label) values (2,'Fax');
+insert into PhoneLabel (Id,Label) values (3,'Other');
+insert into PhoneLabel (Id,Label) values (4,'E-mail');
+insert into PhoneLabel (Id,Label) values (5,'Main');
+insert into PhoneLabel (Id,Label) values (6,'Pager');
+insert into PhoneLabel (Id,Label) values (7,'Mobile');
+
+
+-- Actual address information
+create table Addr (
+	Id            int primary key, -- unique_ID
+	Category      int default(0),
+	Private       int default(0),  -- boolean, zero or one
+	showPhone     int default(1),  -- which of phone1...5 to show as default
+	Lastname      text,
+	Firstname     text,
+	Title         text,
+	Company       text,
+	PhoneLabel1   int,
+	PhoneLabel2   int,
+	PhoneLabel3   int,
+	PhoneLabel4   int,
+	PhoneLabel5   int,
+	Phone1        text,            -- either telephone, fax, e-mail, mobile, etc.
+	Phone2        text,            -- either telephone, fax, e-mail, mobile, etc.
+	Phone3        text,            -- either telephone, fax, e-mail, mobile, etc.
+	Phone4        text,            -- either telephone, fax, e-mail, mobile, etc.
+	Phone5        text,            -- either telephone, fax, e-mail, mobile, etc.
+	Address       text,
+	City          text,
+	State         text,
+	Zip           text,
+	Country       text,
+	Custom1       text,
+	Custom2       text,
+	Custom3       text,
+	Custom4       text,
+	Note          text,
+	InsertDate    text,            -- first insertion date in format YYYY-MM-DDTHH:MM
+	UpdateDate    text,            -- latest update date in format YYYY-MM-DDTHH:MM
+	foreign key (Category) references AddrCategory(Id),
+	foreign key (PhoneLabel1) references PhoneLabel(Id),
+	foreign key (PhoneLabel2) references PhoneLabel(Id),
+	foreign key (PhoneLabel3) references PhoneLabel(Id),
+	foreign key (PhoneLabel4) references PhoneLabel(Id),
+	foreign key (PhoneLabel5) references PhoneLabel(Id)
+);
+
+
+create table Datebook (
+	Id            int primary key,
+	Private       int default(0),  -- boolean, zero or one
+	Timeless      int default(0),  -- boolean, zero or one
+	Begin         text,            -- begin date in format YYYY-MM-DDTHH:MM
+	End           text,            -- end date in format YYYY-MM-DDTHH:MM
+	Alarm         int,             -- boolean, zero or one
+	Advance       int,             -- alarm in advance minutes/hours/days
+	AdvanceUnit   int,             -- 0=minutes, 1=hours, 2=days
+	RepeatType    int,             -- 0=none, 1=daily, 2=weekly, 3=monthly by day, 4=monthly by date, 5=yearly
+	RepeatForever int,             -- boolean, zero or one
+	RepeatEnd     text,            -- end date in format YYYY-MM-DD
+	RepeatFreq    int,
+	RepeatDay     int,
+	RepeatDaySu   int,
+	RepeatDayMo   int,
+	RepeatDayTu   int,
+	RepeatDayWe   int,
+	RepeatDayTh   int,
+	RepeatDayFr   int,
+	RepeatDaySa   int,
+	Exceptions    int,             -- number of exceptions
+	Exception     text,            -- list of dates (format YYYY-MM-DD) separated by space
+	Description   text,
+	Note          text,
+	InsertDate    text,            -- first insertion date in format YYYY-MM-DDTHH:MM
+	UpdateDate    text             -- latest update date in format YYYY-MM-DDTHH:MM
+);
+
+
+-- Labels for ToDo categories, like 'Business', 'Personal', etc.
+create table ToDoCategory (
+	Id            int primary key,
+	Label         text,
+	InsertDate    text,            -- first insertion date in format YYYY-MM-DDTHH:MM
+	UpdateDate    text             -- latest update date in format YYYY-MM-DDTHH:MM
+);
+insert into ToDoCategory (Id,Label) values (0,'Unfiled');
+
+
+create table ToDo (
+	Id            int primary key,
+	Category      int default(0),
+	Private       int default(0),  -- boolean, zero or one
+	Indefinite    int default(0),  -- boolean, zero or one
+	Due           text,            -- due date in format YYYY-MM-DD
+	Priority      int default(1),
+	Complete      int,             -- boolean, zero or one
+	Description   text,
+	Note          text,
+	InsertDate    text,            -- first insertion date in format YYYY-MM-DDTHH:MM
+	UpdateDate    text,            -- latest update date in format YYYY-MM-DDTHH:MM
+	foreign key (Category) references ToDoCategory(Id)
+);
+
+
+-- Labels for memo categories, like 'Business', 'Personal', etc.
+create table MemoCategory (
+	Id            int primary key,
+	Label         text,
+	InsertDate    text,            -- first insertion date in format YYYY-MM-DDTHH:MM
+	UpdateDate    text             -- latest update date in format YYYY-MM-DDTHH:MM
+);
+insert into MemoCategory (Id,Label) values (0,'Unfiled');
+
+
+create table Memo (
+	Id            int primary key,
+	Category      int default(0),
+	Private       int default(0),  -- boolean, zero or one
+	Text          text,
+	InsertDate    text,            -- first insertion date in format YYYY-MM-DDTHH:MM
+	UpdateDate    text,            -- latest update date in format YYYY-MM-DDTHH:MM
+	foreign key (Category) references MemoCategory(Id)
+);
+
+
+-- Labels for expense categories, like 'Project A', 'Internal', etc.
+create table ExpenseCategory (
+	Id            int primary key,
+	Label         text,
+	InsertDate    text,            -- first insertion date in format YYYY-MM-DDTHH:MM
+	UpdateDate    text             -- latest update date in format YYYY-MM-DDTHH:MM
+);
+insert into ExpenseCategory (Id,Label) values (0,'Unfiled');
+
+
+-- Labels for expense types, like 'airfaire', 'car rental', etc.
+create table ExpenseType (
+	Id            int primary key,
+	Label         text
+);
+-- Taken from /usr/include/pi-expense.h
+insert into ExpenseType (Id,Label) values (0,'Airfare');
+insert into ExpenseType (Id,Label) values (1,'Breakfast');
+insert into ExpenseType (Id,Label) values (2,'Bus');
+insert into ExpenseType (Id,Label) values (3,'Business Meals');
+insert into ExpenseType (Id,Label) values (4,'Car Rental');
+insert into ExpenseType (Id,Label) values (5,'Dinner');
+insert into ExpenseType (Id,Label) values (6,'Entertainment');
+insert into ExpenseType (Id,Label) values (7,'Fax');
+insert into ExpenseType (Id,Label) values (8,'Gas');
+insert into ExpenseType (Id,Label) values (9,'Gifts');
+insert into ExpenseType (Id,Label) values (10,'Hotel');
+insert into ExpenseType (Id,Label) values (11,'Incidentals');
+insert into ExpenseType (Id,Label) values (12,'Laundry');
+insert into ExpenseType (Id,Label) values (13,'Limo');
+insert into ExpenseType (Id,Label) values (14,'Lodging');
+insert into ExpenseType (Id,Label) values (15,'Lunch');
+insert into ExpenseType (Id,Label) values (16,'Mileage');
+insert into ExpenseType (Id,Label) values (17,'Other');
+insert into ExpenseType (Id,Label) values (18,'Parking');
+insert into ExpenseType (Id,Label) values (19,'Postage');
+insert into ExpenseType (Id,Label) values (20,'Snack');
+insert into ExpenseType (Id,Label) values (21,'Subway');
+insert into ExpenseType (Id,Label) values (22,'Supplies');
+insert into ExpenseType (Id,Label) values (23,'Taxi');
+insert into ExpenseType (Id,Label) values (24,'Telephone');
+insert into ExpenseType (Id,Label) values (25,'Tips');
+insert into ExpenseType (Id,Label) values (26,'Tolls');
+insert into ExpenseType (Id,Label) values (27,'Train');
+
+
+-- Labels for expense payments, like 'cash', 'Visa', etc.
+create table ExpensePayment (
+	Id            int primary key,
+	Label         text
+);
+-- Taken from /usr/include/pi-expense.h
+insert into ExpensePayment (Id,Label) values (1,'AmEx');
+insert into ExpensePayment (Id,Label) values (2,'Cash');
+insert into ExpensePayment (Id,Label) values (3,'Check');
+insert into ExpensePayment (Id,Label) values (4,'Credit Card');
+insert into ExpensePayment (Id,Label) values (5,'MasterCard');
+insert into ExpensePayment (Id,Label) values (6,'Prepaid');
+insert into ExpensePayment (Id,Label) values (7,'Visa');
+insert into ExpensePayment (Id,Label) values (8,'Unfiled');
+
+
+-- Labels for expense currency, like 'US', 'Germany', etc.
+create table ExpenseCurrency (
+	Id            int primary key,
+	Label         text
+);
+-- Taken from Expense/expense.c
+insert into ExpenseCurrency (Id,Label) values (0,'Australia');
+insert into ExpenseCurrency (Id,Label) values (1,'Austria');
+insert into ExpenseCurrency (Id,Label) values (2,'Belgium');
+insert into ExpenseCurrency (Id,Label) values (3,'Brazil');
+insert into ExpenseCurrency (Id,Label) values (4,'Canada');
+insert into ExpenseCurrency (Id,Label) values (5,'Denmark');
+insert into ExpenseCurrency (Id,Label) values (133,'EU (Euro)');
+insert into ExpenseCurrency (Id,Label) values (6,'Finland');
+insert into ExpenseCurrency (Id,Label) values (7,'France');
+insert into ExpenseCurrency (Id,Label) values (8,'Germany');
+insert into ExpenseCurrency (Id,Label) values (9,'Hong Kong');
+insert into ExpenseCurrency (Id,Label) values (10,'Iceland');
+insert into ExpenseCurrency (Id,Label) values (24,'India');
+insert into ExpenseCurrency (Id,Label) values (25,'Indonesia');
+insert into ExpenseCurrency (Id,Label) values (11,'Ireland');
+insert into ExpenseCurrency (Id,Label) values (12,'Italy');
+insert into ExpenseCurrency (Id,Label) values (13,'Japan');
+insert into ExpenseCurrency (Id,Label) values (26,'Korea');
+insert into ExpenseCurrency (Id,Label) values (14,'Luxembourg');
+insert into ExpenseCurrency (Id,Label) values (27,'Malaysia');
+insert into ExpenseCurrency (Id,Label) values (15,'Mexico');
+insert into ExpenseCurrency (Id,Label) values (16,'Netherlands');
+insert into ExpenseCurrency (Id,Label) values (17,'New Zealand');
+insert into ExpenseCurrency (Id,Label) values (18,'Norway');
+insert into ExpenseCurrency (Id,Label) values (28,'P.R.C.');
+insert into ExpenseCurrency (Id,Label) values (29,'Philippines');
+insert into ExpenseCurrency (Id,Label) values (30,'Singapore');
+insert into ExpenseCurrency (Id,Label) values (19,'Spain');
+insert into ExpenseCurrency (Id,Label) values (20,'Sweden');
+insert into ExpenseCurrency (Id,Label) values (21,'Switzerland');
+insert into ExpenseCurrency (Id,Label) values (32,'Taiwan');
+insert into ExpenseCurrency (Id,Label) values (31,'Thailand');
+insert into ExpenseCurrency (Id,Label) values (22,'United Kingdom');
+insert into ExpenseCurrency (Id,Label) values (23,'United States');
+
+
+create table Expense (
+	Id            int primary key,
+	Category      int default(0),
+	Date          text,            -- date in format YYYY-MM-DD
+	Type          int,             -- 0=airfare, 1=breakfast, etc.
+	Payment       int,             -- 0=AmEx, 1=Cash, etc.
+	Currency      int,
+	Amount        text,
+	Vendor        text,
+	City          text,
+	Attendees     text,
+	Note          text,
+	InsertDate    text,            -- first insertion date in format YYYY-MM-DDTHH:MM
+	UpdateDate    text,            -- latest update date in format YYYY-MM-DDTHH:MM
+	foreign key (Category) references ExpenseCategory(Id),
+	foreign key (Type) references ExpenseType(Id),
+	foreign key (Payment) references ExpensePayment(Id),
+	foreign key (Currency) references ExpenseCurrency(Id)
+);
+
+
+create table Pref (  -- preferences, previously in jpilot.rc
+	Id            int primary key,
+	Name          text not null,   -- Id + name can be used as primary key interchangeably
+	Usertype      text,            -- either 'int' or 'char'
+	Filetype      text,            -- either 'int' or 'char'
+	iValue        int,             -- integer value
+	sValue        text,            -- string value
+	InsertDate    text,            -- first insertion date in format YYYY-MM-DDTHH:MM
+	UpdateDate    text             -- latest update date in format YYYY-MM-DDTHH:MM (not used)
+);
+
+
+create table Alarms (	-- just store last time J-Pilot was ran
+	UpToDate      text
+);
+
+
+

--- a/libplugin.c
+++ b/libplugin.c
@@ -19,6 +19,7 @@
  ******************************************************************************/
 
 /********************************* Includes ***********************************/
+#define _GNU_SOURCE
 #include "config.h"
 #include <stdlib.h>
 #include <stdio.h>
@@ -597,6 +598,10 @@ int jp_read_DB_files(const char *DB_name, GList **records)
 
 const char *jp_strstr(const char *haystack, const char *needle, int case_sense)
 {
+	if (haystack == NULL) return NULL;
+	if (needle == NULL) return haystack;
+	return case_sense ? strstr(haystack, needle) : strcasestr(haystack, needle);
+#ifdef DDT
    char *needle2;
    char *haystack2;
    register char *Ps2;
@@ -641,6 +646,7 @@ const char *jp_strstr(const char *haystack, const char *needle, int case_sense)
       free(haystack2);
       return r;
    }
+#endif
 }
 
 /*

--- a/libsqlite.c
+++ b/libsqlite.c
@@ -1,0 +1,2018 @@
+/* Store J-Pilot data into SQLite3 database directly whenever the data changes in J-Pilot
+
+   Elmar Klausmeier, 20-Sep-2022: Initial revision
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include <time.h>
+extern char *strptime (const char *__restrict __s, const char *__restrict __fmt, struct tm *__tp) __THROW;
+#include <sys/stat.h>
+#include <sqlite3.h>
+
+#include "log.h"
+#include "address.h"
+#include "datebook.h"
+#include "calendar.h"
+#include "memo.h"
+#include "todo.h"
+#include "password.h"
+#include "prefs.h"
+#include "libsqlite.h"
+
+
+// Get bit 5 of x
+#define IS_PRIVATE(x)	((((x) & 0xF0) >> 4) & 0x01)
+// Check if strdup() failed: if pointer returned from SQLite is not NULL, then strdup() it and check for allocation failure
+#define ALLOCN(x,y,E)	{ const char *s=y; if (s) { if ((s=strdup(s))!=NULL) x=(char*)s; else { sqlErr=E; goto errAlloc; } } }
+// Run SQLite command/function x and store error text E
+#define CHK(x,E)	if ((sqlRet = x) != SQLITE_OK) { sqlErr=E; goto err; }
+#define CHKDONE(x,E)	if ((sqlRet = x) != SQLITE_DONE) { sqlErr=E; goto err; }
+#define CHKROW(x,E)	if ((sqlRet = x) != SQLITE_ROW) { sqlErr=E; goto err; }
+// Replace empty strings with NULL
+#define RE(x)	((x && x[0]=='\0') ? NULL : x)
+
+static struct {
+	sqlite3 *conn;	// file global database pointer
+	sqlite3_stmt	// prepared SQL statements
+		*stmtAddrLabelSEL, *stmtAddrCategorySEL, *stmtPhoneLabelSEL,
+		*stmtAddrSELo1, *stmtAddrSELo2, *stmtAddrSELo3, *stmtAddrINS, *stmtAddrUPD, *stmtAddrDEL,
+		*stmtDatebookSEL, *stmtDatebookINS, *stmtDatebookUPD, *stmtDatebookDEL,
+		*stmtMemoCategorySEL, *stmtMemoSEL, *stmtMemoINS, *stmtMemoUPD, *stmtMemoDEL,
+		*stmtToDoCategorySEL, *stmtToDoSEL, *stmtToDoINS, *stmtToDoUPD, *stmtToDoDEL,
+		*stmtExpenseCategorySEL, *stmtExpenseTypeSEL, *stmtExpensePaymentSEL,
+		*stmtExpenseCurrencySEL,
+		*stmtExpenseSEL, *stmtExpenseINS, *stmtExpenseUPD, *stmtExpenseDEL,
+		*stmtPrefSEL, *stmtPrefDEL, *stmtPrefINS;
+	int maxIdAddr, maxIdDatebook, maxIdMemo, maxIdToDo, maxIdExpense;
+} db;
+
+
+
+// Copied from SQLite3 plugin
+int jpsqlite_open(void) {	// return database handle
+	char dbName[FILENAME_MAX];	// path + file-name
+	char sqlFile[FILENAME_MAX];
+	FILE *fp;
+	char *p0;	// points to SQL string in jptables.sql
+	struct stat sqlFStat;
+	//sqlite3 *d = NULL;
+	int sqlRet = 0;
+	const char *sqlErr = "";
+
+	jp_get_home_file_name("jptables.db",dbName,FILENAME_MAX);
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_open(): dbName=%s\n",dbName);
+	if (sqlite3_open_v2(dbName,&db.conn,SQLITE_OPEN_READWRITE,NULL) == SQLITE_OK)
+		return EXIT_SUCCESS;
+
+	// Now try to create new jptables.db by using SQL script
+	// in $HOME/.jpilot/plugins/jptables.sql
+	jp_get_home_file_name("plugins/jptables.sql",sqlFile,FILENAME_MAX);
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_open(): sqlFile=%s\n",sqlFile);
+	if ( stat(sqlFile,&sqlFStat) ) {
+		jp_logf(JP_LOG_FATAL,
+			"jpsqlite_open(): Cannot stat SQL file jptables.sql in plugins directory: %s\n",
+			strerror(errno));
+		return EXIT_FAILURE;
+	}
+	if (sqlFStat.st_size == 0) {
+		jp_logf(JP_LOG_FATAL,"jpsqlite_open(): SQL file jptables.sql has no content\n");
+		return EXIT_FAILURE;
+	}
+	if ((fp = fopen(sqlFile,"r")) == NULL) {
+		jp_logf(JP_LOG_FATAL,
+			"jpsqlite_open(): Cannot open SQL file jptables.sql in plugins directory: %s\n",
+			strerror(errno));
+		return EXIT_FAILURE;
+	}
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_open(): jptables.sql size=%ld\n",
+		sqlFStat.st_size);
+	if ((p0 = malloc(sqlFStat.st_size + 4)) == NULL) {
+		jp_logf(JP_LOG_FATAL,
+			"Cannot cache jptables.sql: %s\n",
+			strerror(errno));
+		return EXIT_FAILURE;
+	}
+	if (fread(p0,1,sqlFStat.st_size,fp) != sqlFStat.st_size) {
+		jp_logf(JP_LOG_FATAL,
+			"jpsqlite_open(): Cannot read jptables.sql: %s\n",
+			strerror(errno));
+		return EXIT_FAILURE;
+	}
+	p0[sqlFStat.st_size] = '\0';
+	// Open and create db
+	jp_logf(JP_LOG_GUI,"\nCreating new SQLite3 database file %s. This may take approx. 20 seconds.\n\n",dbName);
+	CHK(sqlite3_open(dbName,&db.conn),"IOP")
+	// Feed entire file content to SQLite3
+	CHK(sqlite3_exec(db.conn,p0,NULL,NULL,NULL),"IEXC");
+
+	free(p0);
+	if (fclose(fp)) {
+		jp_logf(JP_LOG_FATAL,
+			"jpsqlite_open(): Cannot close jptables.sql: %s\n", strerror(errno));
+		return EXIT_FAILURE;
+	}
+	jp_logf(JP_LOG_GUI,"SQLite3 database created successfully.\n");
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_open(): SQLite3 ret=%d, error=%s, rolling back\n%s\n",
+		sqlRet, sqlErr, sqlite3_errmsg(db.conn));
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_close(void) {
+	int sqlRet = 0;
+	const char *sqlErr = "";
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_close()\n");
+
+	CHK(sqlite3_finalize(db.stmtAddrLabelSEL),"stmtAddrLabelSEL")
+	CHK(sqlite3_finalize(db.stmtAddrCategorySEL),"stmtAddrCategorySEL")
+	CHK(sqlite3_finalize(db.stmtPhoneLabelSEL),"stmtPhoneLabelSEL")
+	CHK(sqlite3_finalize(db.stmtAddrSELo1),"stmtAddrSELo1")
+	CHK(sqlite3_finalize(db.stmtAddrSELo2),"stmtAddrSELo2")
+	CHK(sqlite3_finalize(db.stmtAddrSELo3),"stmtAddrSELo3")
+	CHK(sqlite3_finalize(db.stmtAddrINS),"stmtAddrINS")
+	CHK(sqlite3_finalize(db.stmtAddrUPD),"stmtAddrUPD")
+	CHK(sqlite3_finalize(db.stmtAddrDEL),"stmtAddrDEL")
+	CHK(sqlite3_finalize(db.stmtDatebookSEL),"stmtDatebookSEL")
+	CHK(sqlite3_finalize(db.stmtDatebookINS),"stmtDatebookINS")
+	CHK(sqlite3_finalize(db.stmtDatebookUPD),"stmtDatebookUPD")
+	CHK(sqlite3_finalize(db.stmtDatebookDEL),"stmtDatebookDEL")
+	CHK(sqlite3_finalize(db.stmtMemoCategorySEL),"stmtMemoCategorySEL")
+	CHK(sqlite3_finalize(db.stmtMemoSEL),"stmtMemoSEL")
+	CHK(sqlite3_finalize(db.stmtMemoINS),"stmtMemoINS")
+	CHK(sqlite3_finalize(db.stmtMemoUPD),"stmtMemoUPD")
+	CHK(sqlite3_finalize(db.stmtMemoDEL),"stmtMemoDEL")
+	CHK(sqlite3_finalize(db.stmtToDoCategorySEL),"stmtToDoCategorySEL")
+	CHK(sqlite3_finalize(db.stmtToDoSEL),"stmtToDoSEL")
+	CHK(sqlite3_finalize(db.stmtToDoINS),"stmtToDoINS")
+	CHK(sqlite3_finalize(db.stmtToDoUPD),"stmtToDoUPD")
+	CHK(sqlite3_finalize(db.stmtToDoDEL),"stmtToDoDEL")
+	CHK(sqlite3_finalize(db.stmtExpenseCategorySEL),"stmtExpenseCategorySEL")
+	CHK(sqlite3_finalize(db.stmtExpenseTypeSEL),"stmtExpenseTypeSEL")
+	CHK(sqlite3_finalize(db.stmtExpensePaymentSEL),"stmtExpensePaymentSEL")
+	CHK(sqlite3_finalize(db.stmtExpenseCurrencySEL),"stmtExpenseCurrencySEL")
+	CHK(sqlite3_finalize(db.stmtExpenseSEL),"stmtExpenseSEL")
+	CHK(sqlite3_finalize(db.stmtExpenseINS),"stmtExpenseINS")
+	CHK(sqlite3_finalize(db.stmtExpenseUPD),"stmtExpenseUPD")
+	CHK(sqlite3_finalize(db.stmtExpenseDEL),"stmtExpenseDEL")
+	CHK(sqlite3_finalize(db.stmtPrefSEL),"stmtPrefSEL")
+	CHK(sqlite3_finalize(db.stmtPrefDEL),"stmtPrefDEL")
+	CHK(sqlite3_finalize(db.stmtPrefINS),"stmtPrefINS")
+
+	sqlRet = sqlite3_close(db.conn);	// noop if db==NULL
+	if (sqlRet != SQLITE_OK) {
+		jp_logf(JP_LOG_FATAL,"Cannot close sqlite3 file, sqlRet=%d\n",sqlRet);
+		return EXIT_FAILURE;
+	}
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_close(): SQLite3 ret=%d, error=%s\n%s\n",
+		sqlRet, sqlErr, sqlite3_errmsg(db.conn));
+	sqlite3_close(db.conn);	// noop if db==NULL
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_prepareAllStmt(void) {
+	int sqlRet = 0;
+	const char *sqlErr = "";
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_prepareAllStmt(): Start all prepared statements\n");
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Label from AddrLabel order by Id",
+		-1, &db.stmtAddrLabelSEL, NULL), "jpAddrLabelSEL")
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Label from AddrCategory order by Id",
+		-1, &db.stmtAddrCategorySEL, NULL), "jpAddrCategorySEL")
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Label from PhoneLabel order by Id",
+		-1, &db.stmtPhoneLabelSEL, NULL), "jpPhoneLabelSEL")
+
+	// CATEGORY_ALL == 300
+	#define ADDRSELBASE	\
+		"select Id, Category, Private, showPhone,"	\
+		"    Lastname, Firstname, Title, Company,"	\
+		"    PhoneLabel1, PhoneLabel2, PhoneLabel3, PhoneLabel4, PhoneLabel5,"	\
+		"    Phone1, Phone2, Phone3, Phone4, Phone5,"	\
+		"    Address, City, State, Zip, Country,"	\
+		"    Custom1, Custom2, Custom3, Custom4, Note "	\
+		"from Addr "	\
+		"where (Private=:private0 or Private=:private1) "	\
+		"and (Category=:category or 300=:category) "
+	CHK(sqlite3_prepare_v2(db.conn,ADDRSELBASE
+		"order by Lastname, Firstname, Company",
+		-1, &db.stmtAddrSELo1, NULL), "jpAddrSEL1")
+	CHK(sqlite3_prepare_v2(db.conn,ADDRSELBASE
+		"order by Firstname, Lastname, Company",
+		-1, &db.stmtAddrSELo2, NULL), "jpAddrSEL2")
+	CHK(sqlite3_prepare_v2(db.conn,ADDRSELBASE
+		"order by Company, Lastname, Firstname",
+		-1, &db.stmtAddrSELo3, NULL), "jpAddrSEL3")
+
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"insert into Addr ("
+		"    Id, Category, Private, showPhone,"	// 1
+		"    Lastname, Firstname, Title, Company,"	// 5
+		"    PhoneLabel1, PhoneLabel2, PhoneLabel3,"	// 9
+		"    PhoneLabel4, PhoneLabel5,"		// 12
+		"    Phone1, Phone2, Phone3, Phone4, Phone5,"	// 14
+		"    Address, City, State, Zip, Country,"	// 19
+		"    Custom1, Custom2, Custom3, Custom4,"	// 24
+		"    Note, InsertDate"					// 28
+		") values ("
+		"    :Id, :Category, :Private, :showPhone,"
+		"    :Lastname, :Firstname, :Title, :Company,"
+		"    :PhoneLabel1, :PhoneLabel2, :PhoneLabel3,"
+		"    :PhoneLabel4, :PhoneLabel5,"
+		"    :Phone1, :Phone2, :Phone3, :Phone4, :Phone5,"
+		"    :Address, :City, :State, :Zip, :Country,"
+		"    :Custom1, :Custom2, :Custom3, :Custom4,"
+		"    :Note, strftime('%Y-%m-%dT%H:%M:%S', 'now')"
+		")",
+		-1, &db.stmtAddrINS, NULL), "jpAddrINS")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"update Addr set"
+		"    Category=:Category, Private=:Private, showPhone=:showPhone,"	// 1
+		"    Lastname=:Lastname, Firstname=:Firstname, Title=:Title, Company=:Company,"	// 4
+		"    PhoneLabel1=:PhoneLabel1, PhoneLabel2=:PhoneLabel2, PhoneLabel3=:PhoneLabel3,"	// 8
+		"    PhoneLabel4=:PhoneLabel4, PhoneLabel5=:PhoneLabel5,"		// 11
+		"    Phone1=:Phone1, Phone2=:Phone2, Phone3=:Phone3, Phone4=:Phone4, Phone5=:Phone5,"	// 13
+		"    Address=:Address, City=:City, State=:State, Zip=:Zip, Country=:Country,"	// 18
+		"    Custom1=:Custom1, Custom2=:Custom2, Custom3=:Custom3, Custom4=:Custom4,"	// 23
+		"    Note=:Note, UpdateDate = strftime('%Y-%m-%dT%H:%M:%S', 'now') "					// 27
+		"where Id = :Id",					// 28
+		-1, &db.stmtAddrUPD, NULL), "jpAddrUPD")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"delete from Addr where Id = :Id",
+		-1, &db.stmtAddrDEL, NULL), "jpAddrDEL")
+
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Private, Timeless, Begin, End, Alarm,"	// 0
+		"    Advance, AdvanceUnit, RepeatType, RepeatForever,"	// 6
+		"    RepeatEnd, RepeatFreq, RepeatDay,"	// 10
+		"    RepeatDaySu, RepeatDayMo, RepeatDayTu, RepeatDayWe,"	// 13
+		"    RepeatDayTh, RepeatDayFr, RepeatDaySa,"	// 17
+		"    Exceptions, Exception, Description, Note "	// 20
+		"from Datebook "
+		"where (Private=0 or Private=:private1) "
+		"and ((Begin>=:now||'T00:00' and End<=:now||'T23:59' or RepeatType<>0) or :iNow=0) "
+		"order by substr(Begin,11), Begin, Id",	// order by hh:mm
+		-1, &db.stmtDatebookSEL, NULL), "jpDatebookSEL")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"insert into Datebook ("
+		"    Id, Private, Timeless, Begin, End,"	// 1
+		"    Alarm, Advance, AdvanceUnit, RepeatType,"	// 6
+		"    RepeatForever, RepeatEnd, RepeatFreq,"	// 10
+		"    RepeatDay,"				// 13
+		"    RepeatDaySu, RepeatDayMo, RepeatDayTu,"	// 14
+		"    RepeatDayWe, RepeatDayTh, RepeatDayFr,"	// 17
+		"    RepeatDaySa, Exceptions, Exception,"		// 20
+		"    Description, Note, InsertDate"			// 23
+		") values ("
+		"    :Id, :Private, :Timeless, :Begin, :End,"
+		"    :Alarm, :Advance, :AdvanceUnit, :RepeatType,"
+		"    :RepeatForever, :RepeatEnd, :RepeatFreq,"
+		"    :RepeatDay,"
+		"    :RepeatDaySu, :RepeatDayMo, :RepeatDayTu,"
+		"    :RepeatDayWe, :RepeatDayTh, :RepeatDayFr,"
+		"    :RepeatDaySa, :Exceptions, :Exception,"
+		"    :Description, :Note,"
+		"    strftime('%Y-%m-%dT%H:%M:%S', 'now')"
+		")",
+		-1, &db.stmtDatebookINS, NULL), "jpDatebookINS")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"update Datebook set"
+		"    Private=:Private, Timeless=:Timeless, Begin=:Begin, End=:End, "	// 1
+		"    Alarm=:Alarm, Advance=:Advance, AdvanceUnit=:AdvanceUnit, RepeatType=:RepeatType, "	// 5
+		"    RepeatForever=:RepeatForever, RepeatEnd=:RepeatEnd, RepeatFreq=:RepeatFreq, "	// 9
+		"    RepeatDay=:RepeatDay, "				// 12
+		"    RepeatDaySu=:RepeatDaySu, RepeatDayMo=:RepeatDayMo, RepeatDayTu=:RepeatDayTu, "	// 13
+		"    RepeatDayWe=:RepeatDayWe, RepeatDayTh=:RepeatDayTh, RepeatDayFr=:RepeatDayFr, "	// 16
+		"    RepeatDaySa=:RepeatDaySa, Exceptions=:Exceptions, Exception=:Exception, "	// 19
+		"    Description=:Description, Note=:Note, "		// 22
+		"    UpdateDate = strftime('%Y-%m-%dT%H:%M:%S', 'now') "
+		"where Id = :Id",		// 22
+		-1, &db.stmtDatebookUPD, NULL), "jpDatebookUPD")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"delete from Datebook where Id = :Id",
+		-1, &db.stmtDatebookDEL, NULL), "jpDatebookDEL")
+
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Label from MemoCategory order by Id",
+		-1, &db.stmtMemoCategorySEL, NULL), "jpMemoCategorySEL")
+
+	// CATEGORY_ALL == 300
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Category, Private, Text "
+		"from Memo "
+		"where (Private=:private0 or Private=:private1) "
+		"and (Category=:category or 300=:category) "
+		"order by Text",
+		-1, &db.stmtMemoSEL, NULL), "jpMemoSEL")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"insert into Memo ("
+		"    Id, Category, Private, Text, "
+		"    InsertDate "
+		") values ("
+		"    :Id, :Category, :Private, :Text, "
+		"    strftime('%Y-%m-%dT%H:%M:%S', 'now') "
+		")",
+		-1, &db.stmtMemoINS, NULL), "jpMemoINS")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"update Memo set"
+		"    Category=:Category, Private=:Private, Text=:Text, "
+		"    UpdateDate = strftime('%Y-%m-%dT%H:%M:%S', 'now') "
+		"where Id = :Id",
+		-1, &db.stmtMemoUPD, NULL), "jpMemoUPD")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"delete from Memo where Id = :Id",
+		-1, &db.stmtMemoDEL, NULL), "jpMemoDEL")
+
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Label from ToDoCategory order by Id",
+		-1, &db.stmtToDoCategorySEL, NULL), "jpToDoCategorySEL")
+
+
+	// CATEGORY_ALL == 300
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Category, Private, Indefinite, Due,"
+		"    Priority, Complete, Description, Note "
+		"from ToDo "
+		"where (Private=:private0 or Private=:private1) "
+		"and (Category=:category or 300=:category) "
+		"order by Priority asc, Due desc, Description asc",
+		-1, &db.stmtToDoSEL, NULL), "jpToDoSEL")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"insert into ToDo ("
+		"    Id, Category, Private, Indefinite, "	// 1
+		"    Due, Priority, Complete, "			// 5
+		"    Description, Note, "			// 8
+		"    InsertDate "
+		") values ("
+		"    :Id, :Category, :Private, :Indefinite, "
+		"    :Due, :Priority, :Complete, "
+		"    :Description, :Note, "
+		"    strftime('%Y-%m-%dT%H:%M:%S', 'now') "
+		")",
+		-1, &db.stmtToDoINS, NULL),"jpToDoINS")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"update ToDo set"
+		"    Category=:Category, Private=:Private, Indefinite=:Indefinite, "	// 1
+		"    Due=:Due, Priority=:Priority, Complete=:Complete, "			// 4
+		"    Description=:Description, Note=:Note, "			// 7
+		"    UpdateDate = strftime('%Y-%m-%dT%H:%M:%S', 'now') "
+		"where Id = :Id",				// 9
+		-1, &db.stmtToDoUPD, NULL),"jpToDoUPD")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"delete from ToDo where Id = :Id",
+		-1, &db.stmtToDoDEL, NULL), "jpToDoDEL")
+
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Label from ExpenseCategory order by Id",
+		-1, &db.stmtExpenseCategorySEL, NULL), "jpExpenseCategorySEL")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Label from ExpenseType order by Id",
+		-1, &db.stmtExpenseTypeSEL, NULL), "jpExpenseTypeSEL")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Label from ExpensePayment order by Id",
+		-1, &db.stmtExpensePaymentSEL, NULL), "jpExpensePaymentSEL")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Label from ExpenseCurrency order by Id",
+		-1, &db.stmtExpenseCurrencySEL, NULL), "jpExpenseCurrencySEL")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Category, Date, Type, Payment, Currency,"
+		"    Amount, Vendor, City, Attendees, Note "
+		"from Expense order by Id",
+		-1, &db.stmtExpenseSEL, NULL), "jpExpenseSEL")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"insert into Expense ("
+		"    Id, Category, Date, Type, Payment, "	// 1
+		"    Currency, Amount, Vendor, City, "		// 6
+		"    Attendees, Note, InsertDate "				// 10
+		") values ("
+		"    :Id, :Category, :Date, :Type, :Payment, "
+		"    :Currency, :Amount, :Vendor, :City, "
+		"    :Attendees, :Note, "
+		"    strftime('%Y-%m-%dT%H:%M:%S', 'now') "
+		")",
+		-1, &db.stmtExpenseINS, NULL), "jpExpenseINS")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"update Expense set"
+		"    Category=:Category, Date=:Date, Type=:Type, Payment=:Payment, "	// 1
+		"    Currency=:Currency, Amount=:Amount, Vendor=:Vendor, City=:City, "		// 5
+		"    Attendees=:Attendees, Note=:Note, "				// 9
+		"    UpdateDate = strftime('%Y-%m-%dT%H:%M:%S', 'now') "
+		"where Id = :Id",		// 11
+		-1, &db.stmtExpenseUPD, NULL), "jpExpenseUPD")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"delete from Expense where Id = :Id",
+		-1, &db.stmtExpenseDEL, NULL), "jpExpenseDEL")
+
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select Id, Name, Usertype, Filetype, iValue, sValue from Pref "
+		"order by Id, Name",
+		-1, &db.stmtPrefSEL, NULL), "jpPrefSEL")
+
+	CHK(sqlite3_prepare_v2(db.conn, "delete from Pref",
+		-1, &db.stmtPrefDEL, NULL), "jpPrefDEL")
+
+	CHK(sqlite3_prepare_v2(db.conn,
+		"insert into Pref ("
+		"    Id, Name, Usertype, Filetype, iValue, sValue, InsertDate"
+		") values ("
+		"    :Id, :Name, :Usertype, :Filetype, :iValue, :sValue, strftime('%Y-%m-%dT%H:%M:%S', 'now'))",
+		-1, &db.stmtPrefINS, NULL), "jpPrefINS")
+
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_prepareAllStmt(): Finished all prepared statements\n");
+
+
+	// Read 1+max(Id) from various tables, which might later get INSERT's
+	sqlite3_stmt *stmtMaxIdSEL;
+	CHK(sqlite3_prepare_v2(db.conn,
+		"select"
+		"    1 + (select coalesce(max(Id),0) from Addr),"
+		"    1 + (select coalesce(max(Id),0) from Datebook),"
+		"    1 + (select coalesce(max(Id),0) from Memo),"
+		"    1 + (select coalesce(max(Id),0) from ToDo),"
+		"    1 + (select coalesce(max(Id),0) from Expense)",
+		-1, &stmtMaxIdSEL, NULL), "jpMaxIdSEL")
+	sqlRet = sqlite3_step(stmtMaxIdSEL);
+	if (sqlRet != SQLITE_ROW) goto err;
+	db.maxIdAddr = sqlite3_column_int(stmtMaxIdSEL,0);
+	db.maxIdDatebook = sqlite3_column_int(stmtMaxIdSEL,1);
+	db.maxIdMemo = sqlite3_column_int(stmtMaxIdSEL,2);
+	db.maxIdToDo = sqlite3_column_int(stmtMaxIdSEL,3);
+	db.maxIdExpense = sqlite3_column_int(stmtMaxIdSEL,4);
+	sqlite3_finalize(stmtMaxIdSEL);
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_prepareAllStmt(): maxIdAddr=%d, maxIdDatebook=%d, maxIdMemo=%d, maxIdToDo=%d, maxIdExpense=%d\n",
+		db.maxIdAddr, db.maxIdDatebook, db.maxIdMemo, db.maxIdToDo, db.maxIdExpense);
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_prepareAllStmt(): ret=%d, error=%s, giving up\n%s\n",
+		sqlRet, sqlErr, sqlite3_errmsg(db.conn));
+	//sqlite3_finalize(db.stmtXXX);	// We cannot really do much here
+	//sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_AddrUPD(struct Address *addr, PCRecType rt, unsigned char attrib, unsigned int *unique_id) {
+	int sqlRet = 0, errId;
+	const char *sqlErr = "";
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_AddrUPD(): rt=%d, category=%d, unique_id=%u\n",rt,attrib&0x0F,*unique_id);
+
+	errId = *unique_id;
+	CHK(sqlite3_bind_int(db.stmtAddrUPD,1,attrib & 0x0F),"AddrUpdB1")
+	CHK(sqlite3_bind_int(db.stmtAddrUPD,2,IS_PRIVATE(attrib)),"AddrUpdB2")
+	CHK(sqlite3_bind_int(db.stmtAddrUPD,3,addr->showPhone),"AddrUpdB3")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,4,RE(addr->entry[entryLastname]),-1,SQLITE_STATIC),"AddrUpdB4")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,5,RE(addr->entry[entryFirstname]),-1,SQLITE_STATIC),"AddrUpdB5")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,6,RE(addr->entry[entryTitle]),-1,SQLITE_STATIC),"AddrUpdB6")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,7,RE(addr->entry[entryCompany]),-1,SQLITE_STATIC),"AddrUpdB7")
+	CHK(sqlite3_bind_int(db.stmtAddrUPD,8,addr->phoneLabel[0]),"AddrUpdB8")
+	CHK(sqlite3_bind_int(db.stmtAddrUPD,9,addr->phoneLabel[1]),"AddrUpdB9")
+	CHK(sqlite3_bind_int(db.stmtAddrUPD,10,addr->phoneLabel[2]),"AddrUpdB10")
+	CHK(sqlite3_bind_int(db.stmtAddrUPD,11,addr->phoneLabel[3]),"AddrUpdB11")
+	CHK(sqlite3_bind_int(db.stmtAddrUPD,12,addr->phoneLabel[4]),"AddrUpdB12")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,13,RE(addr->entry[entryPhone1]),-1,SQLITE_STATIC),"AddrUpdB13")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,14,RE(addr->entry[entryPhone2]),-1,SQLITE_STATIC),"AddrUpdB14")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,15,RE(addr->entry[entryPhone3]),-1,SQLITE_STATIC),"AddrUpdB15")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,16,RE(addr->entry[entryPhone4]),-1,SQLITE_STATIC),"AddrUpdB16")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,17,RE(addr->entry[entryPhone5]),-1,SQLITE_STATIC),"AddrUpdB17")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,18,RE(addr->entry[entryAddress]),-1,SQLITE_STATIC),"AddrUpdB18")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,19,RE(addr->entry[entryCity]),-1,SQLITE_STATIC),"AddrUpdB19")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,20,RE(addr->entry[entryState]),-1,SQLITE_STATIC),"AddrUpdB20")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,21,RE(addr->entry[entryZip]),-1,SQLITE_STATIC),"AddrUpdB21")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,22,RE(addr->entry[entryCountry]),-1,SQLITE_STATIC),"AddrUpdB22")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,23,RE(addr->entry[entryCustom1]),-1,SQLITE_STATIC),"AddrUpdB23")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,24,RE(addr->entry[entryCustom2]),-1,SQLITE_STATIC),"AddrUpdB24")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,25,RE(addr->entry[entryCustom3]),-1,SQLITE_STATIC),"AddrUpdB25")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,26,RE(addr->entry[entryCustom4]),-1,SQLITE_STATIC),"AddrUpdB26")
+	CHK(sqlite3_bind_text(db.stmtAddrUPD,27,RE(addr->entry[entryNote]),-1,SQLITE_STATIC),"AddrUpdB27")
+	CHK(sqlite3_bind_int(db.stmtAddrUPD,28,*unique_id),"AddrUpdB28")
+	CHKDONE(sqlite3_step(db.stmtAddrUPD),"AddrUpdST")
+
+	CHK(sqlite3_clear_bindings(db.stmtAddrUPD),"AddrUpdCL")
+	CHK(sqlite3_reset(db.stmtAddrUPD),"AddrUpdRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_AddrINS(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_finalize(db.stmtAddrUPD);
+	//sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+
+int jpsqlite_AddrINS(struct Address *addr, PCRecType rt, unsigned char attrib, unsigned int *unique_id) {
+	int sqlRet = 0, errId;
+	const char *sqlErr = "";
+
+	if (rt == REPLACEMENT_PALM_REC)
+		return jpsqlite_AddrUPD(addr,rt,attrib,unique_id);
+		
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_AddrINS(): rt=%d, category=%d, unique_id=%u, maxIdAddr=%d\n",rt,attrib&0x0F,unique_id?*unique_id:(-1),db.maxIdAddr);
+
+	errId = db.maxIdAddr;
+	if (unique_id) *unique_id = db.maxIdAddr;
+	CHK(sqlite3_bind_int(db.stmtAddrINS,1,db.maxIdAddr),"AddrInsB1")
+	CHK(sqlite3_bind_int(db.stmtAddrINS,2,attrib & 0x0F),"AddrInsB2")
+	CHK(sqlite3_bind_int(db.stmtAddrINS,3,IS_PRIVATE(attrib)),"AddrInsB3")
+	CHK(sqlite3_bind_int(db.stmtAddrINS,4,addr->showPhone),"AddrInsB4")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,5,RE(addr->entry[entryLastname]),-1,SQLITE_STATIC),"AddrInsB5")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,6,RE(addr->entry[entryFirstname]),-1,SQLITE_STATIC),"AddrInsB6")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,7,RE(addr->entry[entryTitle]),-1,SQLITE_STATIC),"AddrInsB7")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,8,RE(addr->entry[entryCompany]),-1,SQLITE_STATIC),"AddrInsB8")
+	CHK(sqlite3_bind_int(db.stmtAddrINS,9,addr->phoneLabel[0]),"AddrInsB9")
+	CHK(sqlite3_bind_int(db.stmtAddrINS,10,addr->phoneLabel[1]),"AddrInsB10")
+	CHK(sqlite3_bind_int(db.stmtAddrINS,11,addr->phoneLabel[2]),"AddrInsB11")
+	CHK(sqlite3_bind_int(db.stmtAddrINS,12,addr->phoneLabel[3]),"AddrInsB12")
+	CHK(sqlite3_bind_int(db.stmtAddrINS,13,addr->phoneLabel[4]),"AddrInsB13")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,14,RE(addr->entry[entryPhone1]),-1,SQLITE_STATIC),"AddrInsB14")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,15,RE(addr->entry[entryPhone2]),-1,SQLITE_STATIC),"AddrInsB15")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,16,RE(addr->entry[entryPhone3]),-1,SQLITE_STATIC),"AddrInsB16")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,17,RE(addr->entry[entryPhone4]),-1,SQLITE_STATIC),"AddrInsB17")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,18,RE(addr->entry[entryPhone5]),-1,SQLITE_STATIC),"AddrInsB18")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,19,RE(addr->entry[entryAddress]),-1,SQLITE_STATIC),"AddrInsB19")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,20,RE(addr->entry[entryCity]),-1,SQLITE_STATIC),"AddrInsB20")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,21,RE(addr->entry[entryState]),-1,SQLITE_STATIC),"AddrInsB21")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,22,RE(addr->entry[entryZip]),-1,SQLITE_STATIC),"AddrInsB22")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,23,RE(addr->entry[entryCountry]),-1,SQLITE_STATIC),"AddrInsB23")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,24,RE(addr->entry[entryCustom1]),-1,SQLITE_STATIC),"AddrInsB24")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,25,RE(addr->entry[entryCustom2]),-1,SQLITE_STATIC),"AddrInsB24")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,26,RE(addr->entry[entryCustom3]),-1,SQLITE_STATIC),"AddrInsB26")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,27,RE(addr->entry[entryCustom4]),-1,SQLITE_STATIC),"AddrInsB27")
+	CHK(sqlite3_bind_text(db.stmtAddrINS,28,RE(addr->entry[entryNote]),-1,SQLITE_STATIC),"AddrInsB28")
+	CHKDONE(sqlite3_step(db.stmtAddrINS),"AddrInsST")
+	db.maxIdAddr += 1;
+	CHK(sqlite3_clear_bindings(db.stmtAddrINS),"AddrInsCL")
+	CHK(sqlite3_reset(db.stmtAddrINS),"AddrInsRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_AddrINS(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_finalize(db.stmtAddrINS);
+	//sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_DatebookUPD(struct CalendarEvent *cale, PCRecType rt, unsigned char attrib, unsigned int *unique_id) {
+	int sqlRet = 0, errId, i, offset, nRealExcp, repeatForever;
+	const char *sqlErr = "";
+	char begin[32], end[32], repeatEnd[32], *pRepeatEnd, exceptionString[2048];
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_DatebookUPD(): rt=%d, unique_id=%u\n",rt,*unique_id);
+	errId = *unique_id;
+
+	strftime(begin,32,"%FT%R",&cale->begin);
+	strftime(end,32,"%FT%R",&cale->end);
+
+	// Data cleansing
+	if (cale->repeatEnd.tm_year < 2  ||  cale->repeatEnd.tm_year > 2050
+	|| cale->repeatEnd.tm_year == 70 && cale->repeatEnd.tm_mon == 0 && cale->repeatEnd.tm_mday == 1)	// 01-Jan-1970
+		pRepeatEnd = NULL;
+	else
+		strftime(pRepeatEnd=repeatEnd,32,"%F",&cale->repeatEnd);
+
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,1,IS_PRIVATE(attrib)),"DatebookUpdB1")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,2,cale->event),"DatebookUpdB2")
+	CHK(sqlite3_bind_text(db.stmtDatebookUPD,3,begin,-1,SQLITE_STATIC),"DatebookUpdB3")
+	CHK(sqlite3_bind_text(db.stmtDatebookUPD,4,end,-1,SQLITE_STATIC),"DatebookUpdB4")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,5,cale->alarm),"DatebookUpdB5")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,6,cale->advance),"DatebookUpdB6")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,7,cale->advanceUnits),"DatebookUpdB7")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,8,cale->repeatType),"DatebookUpdB8")
+	// repeatForever is stored in inverse format as it is used in J-Pilot
+	// in SQLite: repeatForever=1: repeating event, repeatForever=0: non-repeating
+	// old: 1 - (cale->repeatForever & 0x01)
+	// pRepeatEnd && (cale->repeatEnd.tm_year*366 + cale->repeatEnd.tm_yday > cale->begin.tm_year*366 + cale->begin.tm_yday)
+	// && pRepeatEnd == NULL
+	repeatForever = cale->repeatForever & 0x01;
+	if (cale->repeatFrequency == 0 && cale->repeatDay == 0 && cale->repeatDays[0] == 0
+	&& cale->repeatDays[1] == 0 && cale->repeatDays[2] == 0 && cale->repeatDays[3] == 0
+	&& cale->repeatDays[4] == 0 && cale->repeatDays[5] == 0 && cale->repeatDays[6] == 0
+	|| cale->repeatFrequency && pRepeatEnd == NULL)
+		repeatForever = 1;
+	else if (pRepeatEnd && cale->repeatEnd.tm_year*366 + cale->repeatEnd.tm_yday > cale->end.tm_year*366 + cale->end.tm_yday)
+		repeatForever = 0;
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,9,repeatForever),"DatebookUpdB9")
+	CHK(sqlite3_bind_text(db.stmtDatebookUPD,10,pRepeatEnd,-1,SQLITE_STATIC),"DatebookUpdB10")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,11,cale->repeatFrequency),"DatebookUpdB11")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,12,cale->repeatDay),"DatebookUpdB12")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,13,cale->repeatDays[0]),"DatebookUpdB13")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,14,cale->repeatDays[1]),"DatebookUpdB14")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,15,cale->repeatDays[2]),"DatebookUpdB15")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,16,cale->repeatDays[3]),"DatebookUpdB16")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,17,cale->repeatDays[4]),"DatebookUpdB17")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,18,cale->repeatDays[5]),"DatebookUpdB18")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,19,cale->repeatDays[6]),"DatebookUpdB19")
+	// Data cleansing: remove 1900-00-01 tm's
+	for (nRealExcp=0,i=0; i<cale->exceptions; ++i)
+		if (cale->exception[i].tm_year != 0) ++nRealExcp;
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,20,nRealExcp),"DatebookUpdB20")
+	if (nRealExcp * 11 > sizeof(exceptionString)) {
+		jp_logf(JP_LOG_FATAL,"jpsqlite_DatebookUPD(): too many exceptions");
+		exceptionString[0] = '\0';
+	} else {
+		for (i=0,offset=0; i<cale->exceptions; ++i) {
+			if (cale->exception[i].tm_year == 0) continue;	// drop 1900-00-01 tm's
+			strftime(exceptionString+offset,11,"%F",cale->exception+i);
+			if (offset > 0) exceptionString[offset-1] = ' ';	// change previous '\0' to space
+			offset += 11;
+		}
+	}
+	CHK(sqlite3_bind_text(db.stmtDatebookUPD,21,nRealExcp ? exceptionString : NULL,-1,SQLITE_STATIC),"DatebookUpdB21")
+	CHK(sqlite3_bind_text(db.stmtDatebookUPD,22,cale->description,-1,SQLITE_STATIC),"DatebookUpdB22")
+	CHK(sqlite3_bind_text(db.stmtDatebookUPD,23,cale->note,-1,SQLITE_STATIC),"DatebookUpdB23")
+	CHK(sqlite3_bind_int(db.stmtDatebookUPD,24,*unique_id),"DatebookUpdB24")
+	CHKDONE(sqlite3_step(db.stmtDatebookUPD),"DatebookUpdST")
+	db.maxIdDatebook += 1;
+	CHK(sqlite3_clear_bindings(db.stmtDatebookUPD),"DatebookUpdCL")
+	CHK(sqlite3_reset(db.stmtDatebookUPD),"DatebookUpdRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_DatebookUPD(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_finalize(db.stmtDatebookUPD);
+	//sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_DatebookINS(struct CalendarEvent *cale, PCRecType rt, unsigned char attrib, unsigned int *unique_id) {
+	int sqlRet = 0, errId, i, offset, nRealExcp, repeatForever;
+	const char *sqlErr = "";
+	char begin[32], end[32], repeatEnd[32], *pRepeatEnd, exceptionString[2048];
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_DatebookINS(): rt=%d, unique_id=%u, maxIdDatebook=%d\n",rt,unique_id?*unique_id:(-1),db.maxIdDatebook);
+	errId = db.maxIdDatebook;	// ignore provided unique_id, instead get it from database
+	if (unique_id) *unique_id = db.maxIdDatebook;
+
+	strftime(begin,32,"%FT%R",&cale->begin);
+	strftime(end,32,"%FT%R",&cale->end);
+
+	// Data cleansing
+	if (cale->repeatEnd.tm_year < 2  ||  cale->repeatEnd.tm_year > 2050
+	|| cale->repeatEnd.tm_year == 70 && cale->repeatEnd.tm_mon == 0 && cale->repeatEnd.tm_mday == 1)	// 01-Jan-1970
+		pRepeatEnd = NULL;
+	else
+		strftime(pRepeatEnd=repeatEnd,32,"%F",&cale->repeatEnd);
+
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,1,db.maxIdDatebook),"DatebookInsB1")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,2,IS_PRIVATE(attrib)),"DatebookInsB2")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,3,cale->event),"DatebookInsB3")
+	CHK(sqlite3_bind_text(db.stmtDatebookINS,4,begin,-1,SQLITE_STATIC),"DatebookInsB4")
+	CHK(sqlite3_bind_text(db.stmtDatebookINS,5,end,-1,SQLITE_STATIC),"DatebookInsB5")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,6,cale->alarm),"DatebookInsB6")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,7,cale->advance),"DatebookInsB7")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,8,cale->advanceUnits),"DatebookInsB8")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,9,cale->repeatType),"DatebookInsB9")
+	// old: 1 - (cale->repeatForever & 0x01)
+	// pRepeatEnd && (cale->repeatEnd.tm_year*366 + cale->repeatEnd.tm_yday > cale->begin.tm_year*366 + cale->begin.tm_yday)
+	// && pRepeatEnd == NULL
+	if (cale->repeatFrequency == 0 && cale->repeatDay == 0 && cale->repeatDays[0] == 0
+	&& cale->repeatDays[1] == 0 && cale->repeatDays[2] == 0 && cale->repeatDays[3] == 0
+	&& cale->repeatDays[4] == 0 && cale->repeatDays[5] == 0 && cale->repeatDays[6] == 0
+	|| cale->repeatFrequency && pRepeatEnd == NULL)
+		repeatForever = 1;
+	else if (pRepeatEnd && cale->repeatEnd.tm_year*366 + cale->repeatEnd.tm_yday > cale->end.tm_year*366 + cale->end.tm_yday)
+		repeatForever = 0;
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,10,repeatForever),"DatebookInsB10")
+	CHK(sqlite3_bind_text(db.stmtDatebookINS,11,pRepeatEnd,-1,SQLITE_STATIC),"DatebookInsB11")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,12,cale->repeatFrequency),"DatebookInsB12")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,13,cale->repeatDay),"DatebookInsB13")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,14,cale->repeatDays[0]),"DatebookInsB14")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,15,cale->repeatDays[1]),"DatebookInsB15")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,16,cale->repeatDays[2]),"DatebookInsB16")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,17,cale->repeatDays[3]),"DatebookInsB17")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,18,cale->repeatDays[4]),"DatebookInsB18")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,19,cale->repeatDays[5]),"DatebookInsB19")
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,20,cale->repeatDays[6]),"DatebookInsB20")
+	// Data cleansing: remove 1900-00-01 tm's
+	for (nRealExcp=0,i=0; i<cale->exceptions; ++i)
+		if (cale->exception[i].tm_year != 0) ++nRealExcp;
+	CHK(sqlite3_bind_int(db.stmtDatebookINS,21,nRealExcp),"DatebookInsB21")
+	if (nRealExcp * 11 > sizeof(exceptionString)) {
+		jp_logf(JP_LOG_FATAL,"jpsqlite_DatebookINS(): too many exceptions");
+		exceptionString[0] = '\0';
+	} else {
+		for (i=0,offset=0; i<cale->exceptions; ++i) {
+			if (cale->exception[i].tm_year == 0) continue;	// drop 1900-00-01 tm's
+			strftime(exceptionString+offset,11,"%F",cale->exception+i);
+			if (offset > 0) exceptionString[offset-1] = ' ';	// change previous '\0' to space
+			offset += 11;
+		}
+	}
+	CHK(sqlite3_bind_text(db.stmtDatebookINS,22,nRealExcp ? exceptionString : NULL,-1,SQLITE_STATIC),"DatebookInsB22")
+	CHK(sqlite3_bind_text(db.stmtDatebookINS,23,cale->description,-1,SQLITE_STATIC),"DatebookInsB23")
+	CHK(sqlite3_bind_text(db.stmtDatebookINS,24,cale->note,-1,SQLITE_STATIC),"DatebookInsB24")
+	CHKDONE(sqlite3_step(db.stmtDatebookINS),"DatebookInsST")
+	db.maxIdDatebook += 1;
+	CHK(sqlite3_clear_bindings(db.stmtDatebookINS),"DatebookInsCL")
+	CHK(sqlite3_reset(db.stmtDatebookINS),"DatebookInsRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_DatebookINS(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_finalize(db.stmtDatebookINS);
+	//sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_MemoUPD(struct Memo *memo, PCRecType rt, unsigned char attrib, unsigned int *unique_id) {
+	int sqlRet = 0, errId;
+	const char *sqlErr = "";
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_MemoUPD(): rt=%d, category=%d, unique_id=%u\n",rt,attrib&0X0F,*unique_id);
+
+	CHK(sqlite3_bind_int(db.stmtMemoUPD,1,attrib & 0x0F),"MemoUpdB1")
+	CHK(sqlite3_bind_int(db.stmtMemoUPD,2,IS_PRIVATE(attrib)),"MemoUpdB2")
+	CHK(sqlite3_bind_text(db.stmtMemoUPD,3,memo->text,-1,SQLITE_STATIC),"MemoUpdB3")
+	CHK(sqlite3_bind_int(db.stmtMemoUPD,4,*unique_id),"MemoUpdB4")
+	CHKDONE(sqlite3_step(db.stmtMemoUPD),"MemoUpdST")
+
+	CHK(sqlite3_clear_bindings(db.stmtMemoUPD),"MemoUpdCL")
+	CHK(sqlite3_reset(db.stmtMemoUPD),"MemoUpdRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_MemoUPD(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_finalize(db.stmtMemoUPD);
+	//sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_MemoINS(struct Memo *memo, PCRecType rt, unsigned char attrib, unsigned int *unique_id) {
+	int sqlRet = 0, errId;
+	const char *sqlErr = "";
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_MemoINS(): rt=%d, category=%d, unique_id=%u, maxIdMemo=%d\n",rt,attrib&0X0F,unique_id?*unique_id:(-1),db.maxIdMemo);
+	errId = db.maxIdMemo;
+	if (unique_id) *unique_id = db.maxIdMemo;
+
+	CHK(sqlite3_bind_int(db.stmtMemoINS,1,db.maxIdMemo),"MemoInsB1")
+	CHK(sqlite3_bind_int(db.stmtMemoINS,2,attrib & 0x0F),"MemoInsB2")
+	CHK(sqlite3_bind_int(db.stmtMemoINS,3,IS_PRIVATE(attrib)),"MemoInsB3")
+	CHK(sqlite3_bind_text(db.stmtMemoINS,4,memo->text,-1,SQLITE_STATIC),"MemoInsB4")
+	CHKDONE(sqlite3_step(db.stmtMemoINS),"MemoInsST")
+	db.maxIdMemo += 1;
+	CHK(sqlite3_clear_bindings(db.stmtMemoINS),"MemoInsCL")
+	CHK(sqlite3_reset(db.stmtMemoINS),"MemoInsRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_MemoINS(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_finalize(db.stmtMemoINS);
+	//sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_ToDoUPD(struct ToDo *todo, PCRecType rt, unsigned char attrib, unsigned int *unique_id) {
+	int sqlRet = 0, errId;
+	const char *sqlErr = "";
+	char due[32];
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_ToDoUPD(): rt=%d, category=%d, unique_id=%u\n",rt,attrib&0X0F,*unique_id);
+
+	errId = *unique_id;
+
+	//if (rt != PALM_REC && rt != NEW_PC_REC && rt != REPLACEMENT_PALM_REC)
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_ToDoUPD(): unique_id=%u rt=%d, category=%d |%.60s|\n",
+		*unique_id, rt, attrib & 0x0F, todo->description);
+
+	strftime(due,32,"%F",&todo->due);
+	CHK(sqlite3_bind_int(db.stmtToDoUPD,1,attrib & 0x0F),"ToDoUpdB1")
+	CHK(sqlite3_bind_int(db.stmtToDoUPD,2,IS_PRIVATE(attrib)),"ToDoUpdB2")
+	CHK(sqlite3_bind_int(db.stmtToDoUPD,3,todo->indefinite),"ToDoUpdB3")
+	CHK(sqlite3_bind_text(db.stmtToDoUPD,4,due,-1,SQLITE_STATIC),"ToDoUpdB4")
+	CHK(sqlite3_bind_int(db.stmtToDoUPD,5,todo->priority),"ToDoUpdB5")
+	CHK(sqlite3_bind_int(db.stmtToDoUPD,6,todo->complete),"ToDoUpdB6")
+	CHK(sqlite3_bind_text(db.stmtToDoUPD,7,todo->description,-1,SQLITE_STATIC),"ToDoUpdB7")
+	CHK(sqlite3_bind_text(db.stmtToDoUPD,8,todo->note,-1,SQLITE_STATIC),"ToDoUpdB8")
+	CHK(sqlite3_bind_int(db.stmtToDoUPD,9,*unique_id),"ToDoUpdB9")
+	CHKDONE(sqlite3_step(db.stmtToDoUPD),"ToDoUpdST")
+	CHK(sqlite3_clear_bindings(db.stmtToDoUPD),"ToDoUpdCL")
+	CHK(sqlite3_reset(db.stmtToDoUPD),"ToDoUpdRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_ToDoUPD(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_finalize(db.stmtToDoUPD);
+	//sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_ToDoINS(struct ToDo *todo, PCRecType rt, unsigned char attrib, unsigned int *unique_id) {
+	int sqlRet = 0, errId;
+	const char *sqlErr = "";
+	char due[32];
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_ToDoINS(): rt=%d, category=%d, unique_id=%u, maxIdToDo=%d\n",rt,attrib&0X0F,unique_id?*unique_id:(-1),db.maxIdToDo);
+
+	errId = db.maxIdToDo;
+	if (unique_id) *unique_id = db.maxIdToDo;
+
+	if (rt != PALM_REC
+	&&  rt != NEW_PC_REC
+	&&  rt != REPLACEMENT_PALM_REC)
+		jp_logf(JP_LOG_DEBUG,"jpsqlite_ToDoINS(): unique_id=%u rt=%d, category=%d |%.60s|\n",
+				*unique_id, rt, attrib & 0x0F, todo->description);
+
+	strftime(due,32,"%F",&todo->due);
+	CHK(sqlite3_bind_int(db.stmtToDoINS,1,db.maxIdToDo),"ToDoInsB1")
+	CHK(sqlite3_bind_int(db.stmtToDoINS,2,attrib & 0x0F),"ToDoInsB2")
+	CHK(sqlite3_bind_int(db.stmtToDoINS,3,IS_PRIVATE(attrib)),"ToDoInsB3")
+	CHK(sqlite3_bind_int(db.stmtToDoINS,4,todo->indefinite),"ToDoInsB4")
+	CHK(sqlite3_bind_text(db.stmtToDoINS,5,due,-1,SQLITE_STATIC),"ToDoInsB5")
+	CHK(sqlite3_bind_int(db.stmtToDoINS,6,todo->priority),"ToDoInsB6")
+	CHK(sqlite3_bind_int(db.stmtToDoINS,7,todo->complete),"ToDoInsB7")
+	CHK(sqlite3_bind_text(db.stmtToDoINS,8,todo->description,-1,SQLITE_STATIC),"ToDoInsB8")
+	CHK(sqlite3_bind_text(db.stmtToDoINS,9,todo->note,-1,SQLITE_STATIC),"ToDoInsB9")
+	CHKDONE(sqlite3_step(db.stmtToDoINS),"ToDoInsST")
+	db.maxIdToDo += 1;
+	CHK(sqlite3_clear_bindings(db.stmtToDoINS),"ToDoInsCL")
+	CHK(sqlite3_reset(db.stmtToDoINS),"ToDoInsRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_ToDoINS(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_finalize(db.stmtToDoINS);
+	//sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_ExpenseUPD(struct Expense *ex, PCRecType rt, unsigned char attrib, unsigned int *unique_id) {
+	int sqlRet = 0, errId;
+	const char *sqlErr = "";
+	char date[32];
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_ExpenseUPD(): rt=%d, category=%d, unique_id=%u\n",rt,attrib&0X0F,*unique_id);
+
+	CHK(sqlite3_bind_int(db.stmtExpenseUPD,1,attrib & 0x0F),"ExpenseUpdB1")
+	strftime(date,32,"%F",&(ex->date));
+	CHK(sqlite3_bind_text(db.stmtExpenseUPD,2,date,-1,SQLITE_STATIC),"ExpenseUpdB2")
+	CHK(sqlite3_bind_int(db.stmtExpenseUPD,3,ex->type),"ExpenseUpdB3")
+	CHK(sqlite3_bind_int(db.stmtExpenseUPD,4,ex->payment),"ExpenseUpdB4")
+	CHK(sqlite3_bind_int(db.stmtExpenseUPD,5,ex->currency),"ExpenseUpdB5")
+	CHK(sqlite3_bind_text(db.stmtExpenseUPD,6,ex->amount,-1,SQLITE_STATIC),"ExpenseUpdB6")
+	CHK(sqlite3_bind_text(db.stmtExpenseUPD,7,ex->vendor,-1,SQLITE_STATIC),"ExpenseUpdB7")
+	CHK(sqlite3_bind_text(db.stmtExpenseUPD,8,ex->city,-1,SQLITE_STATIC),"ExpenseUpdB8")
+	CHK(sqlite3_bind_text(db.stmtExpenseUPD,9,ex->attendees,-1,SQLITE_STATIC),"ExpenseUpdB9")
+	CHK(sqlite3_bind_text(db.stmtExpenseUPD,10,ex->note,-1,SQLITE_STATIC),"ExpenseUpdB10")
+	CHK(sqlite3_bind_int(db.stmtExpenseUPD,11,*unique_id),"ExpenseUpdB11")
+	CHKDONE(sqlite3_step(db.stmtExpenseUPD),"ExpenseUpdST")
+
+	CHK(sqlite3_clear_bindings(db.stmtExpenseUPD),"ExpenseUpdCL")
+	CHK(sqlite3_reset(db.stmtExpenseUPD),"ExpenseUpdRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_ExpenseUPD(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_finalize(db.stmtExpenseUPD);
+	//sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_ExpenseINS(struct Expense *ex, unsigned char attrib) {
+	int sqlRet = 0, errId;
+	const char *sqlErr = "";
+	char date[32];
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_ExpenseINS(): category=%d, maxIdExpense=%d\n",attrib&0X0F,db.maxIdExpense);
+	errId = db.maxIdExpense;
+
+	CHK(sqlite3_bind_int(db.stmtExpenseINS,1,db.maxIdExpense),"ExpenseInsB1")
+	CHK(sqlite3_bind_int(db.stmtExpenseINS,2,attrib & 0x0F),"ExpenseInsB2")
+	strftime(date,32,"%F",&(ex->date));
+	CHK(sqlite3_bind_text(db.stmtExpenseINS,3,date,-1,SQLITE_STATIC),"ExpenseInsB3")
+	CHK(sqlite3_bind_int(db.stmtExpenseINS,4,ex->type),"ExpenseInsB4")
+	CHK(sqlite3_bind_int(db.stmtExpenseINS,5,ex->payment),"ExpenseInsB5")
+	CHK(sqlite3_bind_int(db.stmtExpenseINS,6,ex->currency),"ExpenseInsB6")
+	CHK(sqlite3_bind_text(db.stmtExpenseINS,7,ex->amount,-1,SQLITE_STATIC),"ExpenseInsB7")
+	CHK(sqlite3_bind_text(db.stmtExpenseINS,8,ex->vendor,-1,SQLITE_STATIC),"ExpenseInsB8")
+	CHK(sqlite3_bind_text(db.stmtExpenseINS,9,ex->city,-1,SQLITE_STATIC),"ExpenseInsB9")
+	CHK(sqlite3_bind_text(db.stmtExpenseINS,10,ex->attendees,-1,SQLITE_STATIC),"ExpenseInsB10")
+	CHK(sqlite3_bind_text(db.stmtExpenseINS,11,ex->note,-1,SQLITE_STATIC),"ExpenseInsB11")
+	CHKDONE(sqlite3_step(db.stmtExpenseINS),"ExpenseInsST")
+	db.maxIdExpense += 1;
+	CHK(sqlite3_clear_bindings(db.stmtExpenseINS),"ExpenseInsCL")
+	CHK(sqlite3_reset(db.stmtExpenseINS),"ExpenseInsRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_ExpenseINS(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_finalize(db.stmtExpenseINS);
+	//sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_Delete(AppType app_type, void *VP) {
+	int sqlRet = 0, errId;
+	const char *sqlErr = "";
+	MyAppointment *mappt;
+	//MyCalendarEvent *mcale;
+	MyAddress *maddr;
+	//MyContact *mcont;
+	MyToDo *mtodo;
+	MyMemo *mmemo;
+	struct MyExpense *mex;
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_Delete(): app_type=%d\n",app_type);
+
+	switch (app_type) {
+		case DATEBOOK:
+			mappt = (MyAppointment*) VP;
+			CHK(sqlite3_bind_int(db.stmtDatebookDEL,1,errId=mappt->unique_id),"DatebookDelB1")
+			CHKDONE(sqlite3_step(db.stmtDatebookDEL),"DatebookDelST")
+			CHK(sqlite3_clear_bindings(db.stmtDatebookDEL),"DatebookDelCL")
+			CHK(sqlite3_reset(db.stmtDatebookDEL),"DatebookDelRST")
+			break;
+		case CALENDAR:
+			//mcale = (MyCalendarEvent*) VP;
+			jp_logf(JP_LOG_FATAL,"SQLite3: Calendar-delete not implemented");
+			break;
+		case ADDRESS:
+			maddr = (MyAddress*) VP;
+			CHK(sqlite3_bind_int(db.stmtAddrDEL,1,errId=maddr->unique_id),"AddrDelB1")
+			CHKDONE(sqlite3_step(db.stmtAddrDEL),"AddrDelST")
+			CHK(sqlite3_clear_bindings(db.stmtAddrDEL),"AddrDelCL")
+			CHK(sqlite3_reset(db.stmtAddrDEL),"AddrDelRST")
+			break;
+		case CONTACTS:
+			//mcont = (MyContact*) VP;
+			jp_logf(JP_LOG_FATAL,"SQLite3: Contact-delete not implemented");
+			break;
+		case TODO:
+			mtodo = (MyToDo*) VP;
+			CHK(sqlite3_bind_int(db.stmtToDoDEL,1,errId=mtodo->unique_id),"ToDoDelB1")
+			CHKDONE(sqlite3_step(db.stmtToDoDEL),"ToDoDelST")
+			CHK(sqlite3_clear_bindings(db.stmtToDoDEL),"ToDoDelCL")
+			CHK(sqlite3_reset(db.stmtToDoDEL),"ToDoDelRST")
+			break;
+		case MEMO:
+			mmemo = (MyMemo*) VP;
+			CHK(sqlite3_bind_int(db.stmtMemoDEL,1,errId=mmemo->unique_id),"MemoDelB1")
+			CHKDONE(sqlite3_step(db.stmtMemoDEL),"MemoDelST")
+			CHK(sqlite3_clear_bindings(db.stmtMemoDEL),"MemoDelCL")
+			CHK(sqlite3_reset(db.stmtMemoDEL),"MemoDelRST")
+			break;
+		case MEMOS+2:	// hacky: should be part of AppType enum
+			mex = (struct MyExpense*) VP;
+			CHK(sqlite3_bind_int(db.stmtExpenseDEL,1,errId=mex->unique_id),"ExpenseDelB1")
+			CHKDONE(sqlite3_step(db.stmtExpenseDEL),"ExpenseDelST")
+			CHK(sqlite3_clear_bindings(db.stmtExpenseDEL),"ExpenseDelCL")
+			CHK(sqlite3_reset(db.stmtExpenseDEL),"ExpenseDelRST")
+			break;
+		default:
+			return EXIT_SUCCESS;
+	}
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_Delete(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	//sqlite3_finalize(db.XXX);
+	//sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_prtAddrAppInfo(struct AddressAppInfo *ai) {
+	int i;
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_prtAddrAppInfo()\n");
+	jp_logf(JP_LOG_DEBUG,"\ttype=%d, country=%d, sortByCompany=%d\n",ai->type,ai->country,ai->sortByCompany);
+	for (i=0; i<22; ++i)
+		jp_logf(JP_LOG_DEBUG,"\tlabelRenamed[%02d]=%d, labels[%02d]=%s\n",i,ai->labelRenamed[i],i,ai->labels[i]);
+	for (i=0; i<8; ++i)
+		jp_logf(JP_LOG_DEBUG,"\tphoneLabels[%d]=%s\n",i,ai->phoneLabels[i]);
+
+	return EXIT_SUCCESS;
+}
+
+
+
+int jpsqlite_AddrLabelSEL(struct AddressAppInfo *ai) {
+	int sqlRet = 0, errId, i, id;
+	const char *sqlErr = "", *label;
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_AddrLabelSEL()\n");
+
+	memset(ai->labels,0,sizeof(ai->labels));	// clear label
+	for (i=0; i<19; ++i) {
+		errId = i;
+		CHKROW(sqlite3_step(db.stmtAddrLabelSEL),"AddrLabelSelST")
+		id = sqlite3_column_int(db.stmtAddrLabelSEL,0);
+		if (i != id) { i = id; jp_logf(JP_LOG_FATAL,"jpsqlite_AddrLabelSEL(),stmtAddrLabelSEL: i != id"); }
+		label = (const char*)sqlite3_column_text(db.stmtAddrLabelSEL,1);	// returns zero-terminated string
+		if (label) strncpy(ai->labels[i],label,15);
+	}
+	CHK(sqlite3_reset(db.stmtAddrLabelSEL),"AddrLabelSelRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_AddrLabelSEL(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	return EXIT_FAILURE;
+}
+
+
+
+
+int jpsqlite_PhoneLabelSEL(struct AddressAppInfo *ai) {
+	int sqlRet = 0, errId, i, id;
+	const char *sqlErr = "", *label;
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_PhoneLabelSEL()\n");
+
+	memset(ai->phoneLabels,0,sizeof(ai->phoneLabels));	// clear all labels
+	for (i=0; i<8; ++i) {
+		errId = i;
+		CHKROW(sqlite3_step(db.stmtPhoneLabelSEL),"PhoneLabelLST")
+		id = sqlite3_column_int(db.stmtPhoneLabelSEL,0);
+		if (i != id) { i = id; jp_logf(JP_LOG_FATAL,"jpsqlite_PhoneLabelSEL(),stmtPhoneLabelSEL: i != id"); }
+		label = (const char*)sqlite3_column_text(db.stmtPhoneLabelSEL,1);	// returns zero-terminated string
+		if (label) strncpy(ai->phoneLabels[i],label,15);	// 16th bytes must be '\0'
+	}
+	CHK(sqlite3_reset(db.stmtPhoneLabelSEL),"PhoneLabelSelRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_PhoneLabelSEL(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_AddrCatSEL(struct AddressAppInfo *ai) {
+	int sqlRet = 0, errId, i;
+	const char *sqlErr = "", *label;
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_AddrCatSEL()\n");
+
+	memset(ai->category.name,0,sizeof(ai->category.name));	// clear all category names
+	memset(ai->category.ID,0,sizeof(ai->category.ID));	// clear all category ID's
+	for (i=0; i<16; ++i) {
+		errId = i;
+		if ((sqlRet = sqlite3_step(db.stmtAddrCategorySEL)) == SQLITE_DONE) break;
+		if (sqlRet != SQLITE_ROW) { sqlErr="AddrCatST"; goto err; }
+		ai->category.ID[i] = sqlite3_column_int(db.stmtAddrCategorySEL,0);
+		//if (i != id) { i = id; jp_logf(JP_LOG_FATAL,"jpsqlite_AddrAppInfo(),stmtAddrCategorySEL: i != id"); }
+		label = (const char*)sqlite3_column_text(db.stmtAddrCategorySEL,1);	// returns zero-terminated string
+		if (label) strncpy(ai->category.name[i],label,15);	// 16th bytes must be '\0'
+	}
+	CHK(sqlite3_reset(db.stmtAddrCategorySEL),"AddrCatSelRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_AddrAppInfo(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	return EXIT_FAILURE;
+}
+
+
+
+// Datebook doesn't use categories, therefore only a simplified version jpsqlite_DatebookCatSEL()
+int jpsqlite_DatebookCatSEL(struct CalendarAppInfo *ai) {
+	memset(ai->category.name,0,sizeof(ai->category.name));	// clear all category names
+	memset(ai->category.ID,0,sizeof(ai->category.ID));	// clear all category ID's
+
+	return EXIT_SUCCESS;
+}
+
+
+
+int jpsqlite_MemoCatSEL(struct MemoAppInfo *ai) {
+	int sqlRet = 0, errId, i;
+	const char *sqlErr = "", *label;
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_MemoCatSEL()\n");
+
+	memset(ai->category.name,0,sizeof(ai->category.name));	// clear all category names
+	memset(ai->category.ID,0,sizeof(ai->category.ID));	// clear all category ID's
+	for (i=0; i<16; ++i) {
+		errId = i;
+		if ((sqlRet = sqlite3_step(db.stmtMemoCategorySEL)) == SQLITE_DONE) break;
+		if (sqlRet != SQLITE_ROW) { sqlErr="MemCatST"; goto err; }
+		ai->category.ID[i] = sqlite3_column_int(db.stmtMemoCategorySEL,0);
+		//if (i != id) { i = id; jp_logf(JP_LOG_FATAL,"jpsqlite_MemoCatSEL(),stmtMemoCategorySEL: i != id\n"); }
+		label = (const char*)sqlite3_column_text(db.stmtMemoCategorySEL,1);	// returns zero-terminated string
+		if (label) strncpy(ai->category.name[i],label,15);	// 16th bytes must be '\0'
+	}
+	CHK(sqlite3_reset(db.stmtMemoCategorySEL),"MemCatRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_MemoCatSEL(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_ToDoCatSEL(struct ToDoAppInfo *ai) {
+	int sqlRet = 0, errId, i;
+	const char *sqlErr = "", *label;
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_ToDoCatSEL()\n");
+
+	memset(ai->category.name,0,sizeof(ai->category.name));	// clear all category names
+	memset(ai->category.ID,0,sizeof(ai->category.ID));	// clear all category ID's
+	for (i=0; i<16; ++i) {
+		errId = i;
+		if ((sqlRet = sqlite3_step(db.stmtToDoCategorySEL)) == SQLITE_DONE) break;
+		if (sqlRet != SQLITE_ROW) { sqlErr="ToDoCatST"; goto err; }
+		ai->category.ID[i] = sqlite3_column_int(db.stmtToDoCategorySEL,0);
+		//if (i != id) { i = id; jp_logf(JP_LOG_FATAL,"jpsqlite_ToDoCatSEL(),stmtToDoCategorySEL: i != id\n"); }
+		label = (const char*)sqlite3_column_text(db.stmtToDoCategorySEL,1);	// returns zero-terminated string
+		//memset(ai->category.name[i],0,16);	// clear category name
+		if (label) strncpy(ai->category.name[i],label,15);	// 16th bytes must be '\0'
+	}
+	CHK(sqlite3_reset(db.stmtToDoCategorySEL),"ToDoCatRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_ToDoCatSEL(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_ExpenseCatSEL(struct ExpenseAppInfo *ai) {
+	int sqlRet = 0, errId, i;
+	const char *sqlErr = "", *label;
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_ExpenseCatSEL()\n");
+
+	memset(ai->category.name,0,sizeof(ai->category.name));	// clear all category names
+	memset(ai->category.ID,0,sizeof(ai->category.ID));	// clear all category ID's
+	for (i=0; i<16; ++i) {
+		errId = i;
+		if ((sqlRet = sqlite3_step(db.stmtExpenseCategorySEL)) == SQLITE_DONE) break;
+		if (sqlRet != SQLITE_ROW) { sqlErr="ExpenseCatST"; goto err; }
+		ai->category.ID[i] = sqlite3_column_int(db.stmtExpenseCategorySEL,0);
+		//if (i != id) { i = id; jp_logf(JP_LOG_FATAL,"jpsqlite_ExpenseCatSEL(),stmtExpenseCategorySEL: i != id"); }
+		label = (const char*)sqlite3_column_text(db.stmtExpenseCategorySEL,1);	// returns zero-terminated string
+		//memset(ai->category.name[i],0,16);	// clear category name
+		if (label) strncpy(ai->category.name[i],label,15);	// 16th bytes must be '\0'
+	}
+	CHK(sqlite3_reset(db.stmtExpenseCategorySEL),"ExpenseCatRST")
+
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_ExpenseCatSEL(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_prtAddrCont(const struct Address *a, struct Contact *c) {
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_prtAddrCont(): left Address, right Contact\n"
+		"\tLastname=%s %s\n"
+		"\tFirstname=%s %s\n"
+		"\tCompany=%s %s\n"
+		"\tTitle=%s %s\n"
+		"\tPhone1=%s %s\n"
+		"\tPhone2=%s %s\n"
+		"\tPhone3=%s %s\n"
+		"\tPhone4=%s %s\n"
+		"\tPhone5=%s %s\n"
+		"\tCustom1=%s %s\n"
+		"\tCustom2=%s %s\n"
+		"\tCustom3=%s %s\n"
+		"\tCustom4=%s %s\n"
+		"\tAddress=%s %s\n"
+		"\tCity=%s %s\n"
+		"\tState=%s %s\n"
+		"\tZip=%s %s\n"
+		"\tCountry=%s %s\n"
+		"\tNote=|%s| |%s|\n",
+		a->entry[entryLastname],c->entry[contLastname],
+		a->entry[entryFirstname],c->entry[contFirstname],
+		a->entry[entryCompany], c->entry[contCompany],
+		a->entry[entryTitle], c->entry[contTitle],
+		a->entry[entryPhone1], c->entry[contPhone1],
+		a->entry[entryPhone2], c->entry[contPhone2],
+		a->entry[entryPhone3], c->entry[contPhone3],
+		a->entry[entryPhone4], c->entry[contPhone4],
+		a->entry[entryPhone5], c->entry[contPhone5],
+		a->entry[entryCustom1], c->entry[contCustom1],
+		a->entry[entryCustom2], c->entry[contCustom2],
+		a->entry[entryCustom3], c->entry[contCustom3],
+		a->entry[entryCustom4], c->entry[contCustom4],
+		a->entry[entryAddress], c->entry[contAddress1],
+		a->entry[entryCity], c->entry[contCity1],
+		a->entry[entryState], c->entry[contState1],
+		a->entry[entryZip], c->entry[contZip1],
+		a->entry[entryCountry], c->entry[contCountry1],
+		a->entry[entryNote], c->entry[contNote]
+	);
+	return 0;
+}
+
+
+
+/*
+ * sort_order: SORT_ASCENDING | SORT_DESCENDING
+ * modified, deleted and private, 0 for no, 1 for yes, 2 for use prefs
+ *
+ * Elmar Klausmeier, 27-Sep-2022: modified + deleted flag are ignored
+ */
+int jpsqlite_AddrSEL(AddressList **address_list, int sort_order, int privates, int category) {
+	int sqlRet=0, errId=0, private0=0, private1=0, recs_returned=0, cat, priv;
+	const char *sqlErr="";
+	AddressList *tm, *tmprev=NULL;
+	sqlite3_stmt *stmt;
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_AddrSEL(): sort_order=%d, privates=%d, category=%d\n",sort_order,privates,category);
+
+	*address_list = NULL;
+	switch (sort_order) {
+		case SORT_BY_LNAME:
+			stmt = db.stmtAddrSELo1;
+			break;
+		case SORT_BY_FNAME:
+			stmt = db.stmtAddrSELo2;
+			break;
+		case SORT_BY_COMPANY:
+			stmt = db.stmtAddrSELo3;
+			break;
+		default:
+			jp_logf(JP_LOG_DEBUG,"jpsqlite_AddrSEL(): sort_order=%d out of range, harmless error\n",sort_order);
+			stmt = db.stmtAddrSELo3;
+			break;
+	}
+	if (privates == 2) privates = show_privates(GET_PRIVATES);
+	if (privates == 1) private1 = 1;
+	CHK(sqlite3_bind_int(stmt,1,private0),"AddrSELB1")	// not really necessary as always zero
+	CHK(sqlite3_bind_int(stmt,2,private1),"AddrSELB2")
+	CHK(sqlite3_bind_int(stmt,3,category),"AddrSELB3")
+
+	for (errId=1; errId<750000; ++errId) {
+		if ((sqlRet = sqlite3_step(stmt)) == SQLITE_DONE) break;
+		if (sqlRet != SQLITE_ROW) { sqlErr="ADDRSELST"; goto err; }
+		// calloc important here so as to clear out all(!) pointers
+		if ((tm = calloc(1,sizeof(AddressList))) == NULL) { sqlErr="tm"; goto errAlloc; }
+		tm->maddr.unique_id = sqlite3_column_int(stmt,0);
+		cat = sqlite3_column_int(stmt,1);
+		priv = sqlite3_column_int(stmt,2);
+		tm->maddr.attrib = (cat & 0x0F) | (priv << 4);
+		tm->maddr.addr.showPhone = sqlite3_column_int(stmt,3);
+		ALLOCN(tm->maddr.addr.entry[entryLastname],sqlite3_column_text(stmt,4),"tm->maddr.addr.entry[entryLastname]")
+		ALLOCN(tm->maddr.addr.entry[entryFirstname],sqlite3_column_text(stmt,5),"tm->maddr.addr.entry[entryFirstname]")
+		ALLOCN(tm->maddr.addr.entry[entryTitle],sqlite3_column_text(stmt,6),"tm->maddr.addr.entry[entryTitle]")
+		ALLOCN(tm->maddr.addr.entry[entryCompany],sqlite3_column_text(stmt,7),"tm->maddr.addr.entry[entryCompany]")
+		tm->maddr.addr.phoneLabel[0] = sqlite3_column_int(stmt,8);
+		tm->maddr.addr.phoneLabel[1] = sqlite3_column_int(stmt,9);
+		tm->maddr.addr.phoneLabel[2] = sqlite3_column_int(stmt,10);
+		tm->maddr.addr.phoneLabel[3] = sqlite3_column_int(stmt,11);
+		tm->maddr.addr.phoneLabel[4] = sqlite3_column_int(stmt,12);
+		ALLOCN(tm->maddr.addr.entry[entryPhone1],sqlite3_column_text(stmt,13),"tm->maddr.addr.entry[entryPhone1]")
+		ALLOCN(tm->maddr.addr.entry[entryPhone2],sqlite3_column_text(stmt,14),"tm->maddr.addr.entry[entryPhone2]")
+		ALLOCN(tm->maddr.addr.entry[entryPhone3],sqlite3_column_text(stmt,15),"tm->maddr.addr.entry[entryPhone3]")
+		ALLOCN(tm->maddr.addr.entry[entryPhone4],sqlite3_column_text(stmt,16),"tm->maddr.addr.entry[entryPhone4]")
+		ALLOCN(tm->maddr.addr.entry[entryPhone5],sqlite3_column_text(stmt,17),"tm->maddr.addr.entry[entryPhone5]")
+		ALLOCN(tm->maddr.addr.entry[entryAddress],sqlite3_column_text(stmt,18),"tm->maddr.addr.entry[entryAddress]")
+		ALLOCN(tm->maddr.addr.entry[entryCity],sqlite3_column_text(stmt,19),"tm->maddr.addr.entry[entryCity]")
+		ALLOCN(tm->maddr.addr.entry[entryState],sqlite3_column_text(stmt,20),"tm->maddr.addr.entry[entryState]")
+		ALLOCN(tm->maddr.addr.entry[entryZip],sqlite3_column_text(stmt,21),"tm->maddr.addr.entry[entryZip]")
+		ALLOCN(tm->maddr.addr.entry[entryCountry],sqlite3_column_text(stmt,22),"tm->maddr.addr.entry[entryCountry]")
+		ALLOCN(tm->maddr.addr.entry[entryCustom1],sqlite3_column_text(stmt,23),"tm->maddr.addr.entry[entryCustom1]")
+		ALLOCN(tm->maddr.addr.entry[entryCustom2],sqlite3_column_text(stmt,24),"tm->maddr.addr.entry[entryCustom2]")
+		ALLOCN(tm->maddr.addr.entry[entryCustom3],sqlite3_column_text(stmt,25),"tm->maddr.addr.entry[entryCustom3]")
+		ALLOCN(tm->maddr.addr.entry[entryCustom4],sqlite3_column_text(stmt,26),"tm->maddr.addr.entry[entryCustom4]")
+		ALLOCN(tm->maddr.addr.entry[entryNote],sqlite3_column_text(stmt,27),"tm->maddr.addr.entry[entryNote]")
+		tm->app_type = ADDRESS;
+		//tm->next = NULL;	// already zero due to calloc()
+		tm->maddr.rt = PALM_REC;	//NEW_PC_REC;
+		if (*address_list == NULL) *address_list = tm;	// start of list
+		else tmprev->next = tm;	// previous points to current
+		tmprev = tm;	// remember for next round
+		recs_returned++;
+#ifdef JPILOT_DEBUG
+		jp_logf(JP_LOG_DEBUG,"jpsqlite_AddrSEL():\n"
+			"\tattrib=%0x\n"
+			"\tLastname=%s\n"
+			"\tFirstname=%s\n"
+			"\tCompany=%s\n"
+			"\tTitle=%s\n"
+			"\tPhoneLabel1-5=%d %d %d %d %d\n"
+			"\tPhone1=%s\n"
+			"\tPhone2=%s\n"
+			"\tPhone3=%s\n"
+			"\tPhone4=%s\n"
+			"\tPhone5=%s\n"
+			"\tCustom1=%s\n"
+			"\tCustom2=%s\n"
+			"\tCustom3=%s\n"
+			"\tCustom4=%s\n"
+			"\tAddress=%s\n"
+			"\tCity=%s\n"
+			"\tState=%s\n"
+			"\tZip=%s\n"
+			"\tCountry=%s\n"
+			"\tNote=|%s|\n",
+			tm->maddr.attrib,
+			tm->maddr.addr.entry[entryLastname],
+			tm->maddr.addr.entry[entryFirstname],
+			tm->maddr.addr.entry[entryCompany],
+			tm->maddr.addr.entry[entryTitle],
+			tm->maddr.addr.phoneLabel[0], tm->maddr.addr.phoneLabel[1], tm->maddr.addr.phoneLabel[2], tm->maddr.addr.phoneLabel[3], tm->maddr.addr.phoneLabel[4],
+			tm->maddr.addr.entry[entryPhone1],
+			tm->maddr.addr.entry[entryPhone2],
+			tm->maddr.addr.entry[entryPhone3],
+			tm->maddr.addr.entry[entryPhone4],
+			tm->maddr.addr.entry[entryPhone5],
+			tm->maddr.addr.entry[entryCustom1],
+			tm->maddr.addr.entry[entryCustom2],
+			tm->maddr.addr.entry[entryCustom3],
+			tm->maddr.addr.entry[entryCustom4],
+			tm->maddr.addr.entry[entryAddress],
+			tm->maddr.addr.entry[entryCity],
+			tm->maddr.addr.entry[entryState],
+			tm->maddr.addr.entry[entryZip],
+			tm->maddr.addr.entry[entryCountry],
+			tm->maddr.addr.entry[entryNote]
+		);
+#endif
+	}
+	CHK(sqlite3_clear_bindings(stmt),"ADDRSELCL")
+	CHK(sqlite3_reset(stmt),"ADDRSELRST")
+	return recs_returned;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_AddrSEL(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_clear_bindings(stmt);
+	sqlite3_reset(stmt);
+	return 0;	// zero elements
+
+errAlloc:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_AddrSEL(): memory allocation error for %s\n",sqlErr);
+	sqlite3_clear_bindings(stmt);
+	sqlite3_reset(stmt);
+	return 0;	// zero elements
+}
+
+
+
+/*
+ * If NULL is passed in for date, then all appointments will be returned.
+ * Otherwise return all appointments for date=now.
+ * modified, deleted and private, 0 for no, 1 for yes, 2 for use prefs
+ */
+int jpsqlite_DatebookSEL(CalendarEventList **calendar_event_list, struct tm *now, int privates) {
+	int i, offset, sqlRet=0, errId=0, private1=0, recs_returned=0, priv, iNow=0, tmUsed=1;
+	const char *sqlErr="", *begin, *end, *pRepeatEnd;
+	char pNow[16];
+	const char *excp;
+	CalendarEventList *tm=NULL, *tmprev=NULL;
+
+	*calendar_event_list = NULL;
+	pNow[0] = '\0';
+	if (now) { iNow = 1; strftime(pNow,16,"%F",now); }
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_DatebookSEL(): privates=%d, now=%s\n",privates,pNow);
+	if (privates == 2) privates = show_privates(GET_PRIVATES);
+	if (privates == 1) private1 = 1;
+	//CHK(sqlite3_bind_int(db.stmtDatebookSEL,1,private0),"DatebookSelB1")
+	CHK(sqlite3_bind_int(db.stmtDatebookSEL,1,private1),"DatebookSelB1")
+	CHK(sqlite3_bind_text(db.stmtDatebookSEL,2,pNow,-1,SQLITE_STATIC),"DatebookSelB2")
+	CHK(sqlite3_bind_int(db.stmtDatebookSEL,3,iNow),"DatebookSelB3")
+
+	for (errId=1; errId<750000; ++errId) {
+		if ((sqlRet = sqlite3_step(db.stmtDatebookSEL)) == SQLITE_DONE) break;
+		if (sqlRet != SQLITE_ROW) { sqlErr="DatebookSelST"; goto err; }
+		if (tmUsed) {
+			// calloc important here so as to clear out all(!) pointers
+			if ((tm = calloc(1,sizeof(CalendarEventList))) == NULL) { sqlErr="tm"; goto errAlloc; }
+		} else {
+			memset(tm,'\0',sizeof(CalendarEventList));	// clear previous stuff
+		}
+/***
+		// Data cleansing
+		if (c->mcale.cale.repeatEnd.tm_year < 2
+		||  c->mcale.cale.repeatEnd.tm_year > 2050)
+			pRepeatEnd = NULL;
+		else
+			strftime(pRepeatEnd=repeatEnd,32,"%F",&c->mcale.cale.repeatEnd);
+***/
+		tm->mcale.unique_id = sqlite3_column_int(db.stmtDatebookSEL,0);
+		priv = sqlite3_column_int(db.stmtDatebookSEL,1);
+		tm->mcale.attrib = priv << 4;
+		tm->mcale.cale.event = sqlite3_column_int(db.stmtDatebookSEL,2);
+		begin = (const char*)sqlite3_column_text(db.stmtDatebookSEL,3);
+		if (begin && strlen(begin) >= 16) strptime(begin,"%FT%R",&(tm->mcale.cale.begin));
+		end = (const char*)sqlite3_column_text(db.stmtDatebookSEL,4);
+		if (end && strlen(end) >= 16) strptime(end,"%FT%R",&(tm->mcale.cale.end));
+		tm->mcale.cale.alarm = sqlite3_column_int(db.stmtDatebookSEL,5);
+		tm->mcale.cale.advance = sqlite3_column_int(db.stmtDatebookSEL,6);
+		tm->mcale.cale.advanceUnits = sqlite3_column_int(db.stmtDatebookSEL,7);
+		tm->mcale.cale.repeatType = sqlite3_column_int(db.stmtDatebookSEL,8);
+		// old: 1-x
+		tm->mcale.cale.repeatForever = (sqlite3_column_int(db.stmtDatebookSEL,9) & 0x01);
+		pRepeatEnd = (const char*)sqlite3_column_text(db.stmtDatebookSEL,10);
+		if (pRepeatEnd && strlen(pRepeatEnd) >= 10) strptime(pRepeatEnd,"%F",&(tm->mcale.cale.repeatEnd));
+		tm->mcale.cale.repeatFrequency = sqlite3_column_int(db.stmtDatebookSEL,11);
+		tm->mcale.cale.repeatDay = sqlite3_column_int(db.stmtDatebookSEL,12);
+		tm->mcale.cale.repeatDays[0] = sqlite3_column_int(db.stmtDatebookSEL,13);
+		tm->mcale.cale.repeatDays[1] = sqlite3_column_int(db.stmtDatebookSEL,14);
+		tm->mcale.cale.repeatDays[2] = sqlite3_column_int(db.stmtDatebookSEL,15);
+		tm->mcale.cale.repeatDays[3] = sqlite3_column_int(db.stmtDatebookSEL,16);
+		tm->mcale.cale.repeatDays[4] = sqlite3_column_int(db.stmtDatebookSEL,17);
+		tm->mcale.cale.repeatDays[5] = sqlite3_column_int(db.stmtDatebookSEL,18);
+		tm->mcale.cale.repeatDays[6] = sqlite3_column_int(db.stmtDatebookSEL,19);
+		tm->mcale.cale.exceptions = sqlite3_column_int(db.stmtDatebookSEL,20);
+		if (tm->mcale.cale.exceptions == 0) {
+			tm->mcale.cale.exception = NULL;
+		} else if ((excp = sqlite3_column_text(db.stmtDatebookSEL,21)) != NULL) {
+			if ((tm->mcale.cale.exception = calloc(tm->mcale.cale.exceptions,sizeof(struct tm))) == NULL) {
+				sqlErr = "tm->mcale.cale.exception";
+				goto errAlloc;
+			}
+			for (i=0,offset=0; i<tm->mcale.cale.exceptions; ++i,offset+=11) {
+				strptime(excp+offset,"%F",tm->mcale.cale.exception+i);
+				tm->mcale.cale.exception[i].tm_hour = 12;	// probably useful for dateToDays() calculation
+			}
+		}
+		if (now && !calendar_isApptOnDate(&(tm->mcale.cale),now) ) {
+			tmUsed = 0;	// we can re-use tm
+			if (tm->mcale.cale.exception) free(tm->mcale.cale.exception);
+			continue;	// similar to logic in calendar.c:get_days_calendar_events2()
+		}
+		ALLOCN(tm->mcale.cale.description,sqlite3_column_text(db.stmtDatebookSEL,22),"tm->mcale.cale.description")
+		ALLOCN(tm->mcale.cale.note,sqlite3_column_text(db.stmtDatebookSEL,23),"tm->mcale.cale.note")
+		tm->app_type = CALENDAR;
+		//tm->next = NULL;	// already zero due to calloc()
+		tm->mcale.rt = PALM_REC;	//NEW_PC_REC;
+		if (*calendar_event_list == NULL) *calendar_event_list = tm;	// start of list
+		else tmprev->next = tm;	// previous points to current
+		tmprev = tm;	// remember for next round
+		tmUsed = 1;	// tm is part of linked list
+		recs_returned++;
+	}
+	if (tmUsed == 0) free(tm);
+	CHK(sqlite3_clear_bindings(db.stmtDatebookSEL),"DatebookSelCL")
+	CHK(sqlite3_reset(db.stmtDatebookSEL),"DatebookSelRST")
+	return recs_returned;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_DatebookSEL(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_clear_bindings(db.stmtDatebookSEL);
+	sqlite3_reset(db.stmtDatebookSEL);
+	return 0;	// zero elements
+
+errAlloc:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_DatebookSEL(): memory allocation error for %ss\n",sqlErr);
+	sqlite3_clear_bindings(db.stmtDatebookSEL);
+	sqlite3_reset(db.stmtDatebookSEL);
+	return 0;	// zero elements
+}
+
+
+
+/*
+ * sort_order: SORT_ASCENDING | SORT_DESCENDING (used to keep pdb sort order
+ *                                               but not yet implemented)
+ * modified, deleted, private: 0 for no, 1 for yes, 2 for use prefs
+ *
+ * Elmar Klausmeier, 26-Sep-2022: sort_order + modified + deleted flag are ignored
+ * Memos are always returned sorted in ascending order, see stmtMemoSEL
+ */
+int jpsqlite_MemoSEL(MemoList **memo_list, int privates, int category) {
+	int sqlRet=0, errId=0, private0=0, private1=0, recs_returned=0, cat, priv;
+	const char *sqlErr="";
+	MemoList *tm, *tmprev=NULL;
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_MemoSEL(): privates=%d, category=%d\n",privates,category);
+
+	*memo_list = NULL;
+	if (privates == 2) privates = show_privates(GET_PRIVATES);
+	if (privates == 1) private1 = 1;
+	CHK(sqlite3_bind_int(db.stmtMemoSEL,1,private0),"MemoSELB1")
+	CHK(sqlite3_bind_int(db.stmtMemoSEL,2,private1),"MemoSELB2")
+	CHK(sqlite3_bind_int(db.stmtMemoSEL,3,category),"MemoSELB3")
+
+	for (errId=1; errId<750000; ++errId) {
+		if ((sqlRet = sqlite3_step(db.stmtMemoSEL)) == SQLITE_DONE) break;
+		if (sqlRet != SQLITE_ROW) { sqlErr="MemoSELST"; goto err; }
+		// calloc important here so as to clear out all(!) pointers
+		if ((tm = calloc(1,sizeof(MemoList))) == NULL) { sqlErr="tm"; goto errAlloc; }
+		tm->mmemo.unique_id = sqlite3_column_int(db.stmtMemoSEL,0);
+		cat = sqlite3_column_int(db.stmtMemoSEL,1);
+		priv = sqlite3_column_int(db.stmtMemoSEL,2);
+		tm->mmemo.attrib = (cat & 0x0F) | (priv << 4);
+		ALLOCN(tm->mmemo.memo.text,sqlite3_column_text(db.stmtMemoSEL,3),"tm->mmemo.memo.text")
+		tm->app_type = MEMO;
+		//tm->next = NULL;	// already zero due to calloc()
+		tm->mmemo.rt = PALM_REC;	//NEW_PC_REC;
+		if (*memo_list == NULL) *memo_list = tm;	// start of list
+		else tmprev->next = tm;	// previous points to current
+		tmprev = tm;	// remember for next round
+		recs_returned++;
+	}
+	CHK(sqlite3_clear_bindings(db.stmtMemoSEL),"MemoSELCL")
+	CHK(sqlite3_reset(db.stmtMemoSEL),"MemoSELRST")
+	return recs_returned;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_MemoSEL(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_clear_bindings(db.stmtMemoSEL);
+	sqlite3_reset(db.stmtMemoSEL);
+	return 0;	// zero elements
+
+errAlloc:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_MemoSEL(): memory allocation error for %s\n",sqlErr);
+	sqlite3_clear_bindings(db.stmtMemoSEL);
+	sqlite3_reset(db.stmtMemoSEL);
+	return 0;	// zero elements
+}
+
+
+
+/*
+ * sort_order: SORT_ASCENDING | SORT_DESCENDING
+ * modified, deleted, private, completed:
+ *  0 for no, 1 for yes, 2 for use prefs
+ *
+ * Elmar Klausmeier, 27-Sep-2022: sort_order + modified + deleted + completed flag are ignored
+ * ToDos are always returned sorted in order by Priority asc, Due desc, Description asc,
+ * see stmtToDoSEL
+ */
+int jpsqlite_ToDoSEL(ToDoList **todo_list, int privates, int category) {
+	int sqlRet=0, errId=0, id, private0=0, private1=0, recs_returned=0, cat, priv;
+	const char *sqlErr="", *due;
+	ToDoList *tm, *tmprev=NULL;
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_ToDoSEL(): privates=%d, category=%d\n",privates,category);
+
+	*todo_list = NULL;
+	if (privates == 2) privates = show_privates(GET_PRIVATES);
+	if (privates == 1) private1 = 1;
+	CHK(sqlite3_bind_int(db.stmtToDoSEL,1,private0),"TODOSELB1")
+	CHK(sqlite3_bind_int(db.stmtToDoSEL,2,private1),"TODOSELB2")
+	CHK(sqlite3_bind_int(db.stmtToDoSEL,3,category),"TODOSELB3")
+
+	for (id=1; id<750000; ++id) {
+		errId = id;
+		if ((sqlRet = sqlite3_step(db.stmtToDoSEL)) == SQLITE_DONE) break;
+		if (sqlRet != SQLITE_ROW) { sqlErr="ToDoSELST"; goto err; }
+		// calloc important here so as to clear out all(!) pointers
+		if ((tm = calloc(1,sizeof(ToDoList))) == NULL) { sqlErr="tm"; goto errAlloc; }
+		tm->mtodo.unique_id = sqlite3_column_int(db.stmtToDoSEL,0);
+		cat = sqlite3_column_int(db.stmtToDoSEL,1);
+		priv = sqlite3_column_int(db.stmtToDoSEL,2);
+		tm->mtodo.attrib = (cat & 0x0F) | (priv << 4);
+		tm->mtodo.todo.indefinite = sqlite3_column_int(db.stmtToDoSEL,3);
+		due = (const char*)sqlite3_column_text(db.stmtToDoSEL,4);	// returns zero-terminated string
+		tm->mtodo.todo.priority = sqlite3_column_int(db.stmtToDoSEL,5);
+		tm->mtodo.todo.complete = sqlite3_column_int(db.stmtToDoSEL,6);
+		ALLOCN(tm->mtodo.todo.description,sqlite3_column_text(db.stmtToDoSEL,7),"tm->mtodo.todo.description")
+		ALLOCN(tm->mtodo.todo.note,sqlite3_column_text(db.stmtToDoSEL,8),"tm->mtodo.todo.note")
+		tm->app_type = TODO;
+		//tm->next = NULL;	// already zero due to calloc()
+		tm->mtodo.rt = PALM_REC;	//NEW_PC_REC;
+		if (due && strlen(due) >= 10) strptime(due,"%F",&(tm->mtodo.todo.due));
+		if (*todo_list == NULL) *todo_list = tm;	// start of list
+		else tmprev->next = tm;	// previous points to current
+		tmprev = tm;	// remember for next round
+		recs_returned++;
+	}
+	CHK(sqlite3_clear_bindings(db.stmtToDoSEL),"ToDoSELCL")
+	CHK(sqlite3_reset(db.stmtToDoSEL),"ToDoSELRST")
+	return recs_returned;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_ToDoSEL(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_clear_bindings(db.stmtToDoSEL);
+	sqlite3_reset(db.stmtToDoSEL);
+	return 0;	// zero elements
+
+errAlloc:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_ToDoSEL(): memory allocation error for %s\n",sqlErr);
+	sqlite3_clear_bindings(db.stmtToDoSEL);
+	sqlite3_reset(db.stmtToDoSEL);
+	return 0;	// zero elements
+}
+
+
+
+/* Return expense list
+ * Elmar Klausmeier, 14-Oct-2022
+ */
+int jpsqlite_ExpenseSEL(struct MyExpense **expense_list) {
+	int sqlRet=0, errId=0, id, private0=0, private1=0, recs_returned=0, cat, priv;
+	const char *sqlErr="", *date;
+	struct MyExpense *tm, *tmprev=NULL;
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_ExpenseSEL()\n");
+
+	*expense_list = NULL;
+	for (id=1; id<750000; ++id) {
+		errId = id;
+		if ((sqlRet = sqlite3_step(db.stmtExpenseSEL)) == SQLITE_DONE) break;
+		if (sqlRet != SQLITE_ROW) { sqlErr="ExpenseSELST"; goto err; }
+		// calloc important here so as to clear out all(!) pointers
+		if ((tm = calloc(1,sizeof(struct MyExpense))) == NULL) { sqlErr="tm"; goto errAlloc; }
+		tm->unique_id = sqlite3_column_int(db.stmtExpenseSEL,0);
+		tm->attrib = sqlite3_column_int(db.stmtExpenseSEL,1) & 0x0F;
+		date = (const char*)sqlite3_column_text(db.stmtExpenseSEL,2);	// returns zero-terminated string
+		if (date && strlen(date) >= 10) strptime(date,"%F",&(tm->ex.date));
+		tm->ex.type = sqlite3_column_int(db.stmtExpenseSEL,3);
+		tm->ex.payment = sqlite3_column_int(db.stmtExpenseSEL,4);
+		tm->ex.currency = sqlite3_column_int(db.stmtExpenseSEL,5);
+		ALLOCN(tm->ex.amount,sqlite3_column_text(db.stmtExpenseSEL,6),"tm->ex.amount")
+		ALLOCN(tm->ex.vendor,sqlite3_column_text(db.stmtExpenseSEL,7),"tm->ex.vendor")
+		ALLOCN(tm->ex.city,sqlite3_column_text(db.stmtExpenseSEL,8),"tm->ex.city")
+		ALLOCN(tm->ex.attendees,sqlite3_column_text(db.stmtExpenseSEL,9),"tm->ex.attendees")
+		ALLOCN(tm->ex.note,sqlite3_column_text(db.stmtExpenseSEL,10),"tm->ex.note")
+		//tm->next = NULL;	// already zero due to calloc()
+		if (*expense_list == NULL) *expense_list = tm;	// start of list
+		else tmprev->next = tm;	// previous points to current
+		tmprev = tm;	// remember for next round
+		recs_returned++;
+	}
+	CHK(sqlite3_clear_bindings(db.stmtExpenseSEL),"ExpenseSELCL")
+	CHK(sqlite3_reset(db.stmtExpenseSEL),"ExpenseSELRST")
+	return recs_returned;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_ExpenseSEL(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_clear_bindings(db.stmtExpenseSEL);
+	sqlite3_reset(db.stmtExpenseSEL);
+	return 0;	// zero elements
+
+errAlloc:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_ExpenseSEL(): memory allocation error for %s\n",sqlErr);
+	sqlite3_clear_bindings(db.stmtExpenseSEL);
+	sqlite3_reset(db.stmtExpenseSEL);
+	return 0;	// zero elements
+}
+
+
+
+/* Write categories: delete + write-all
+ * As these operations occur rarely, no prepared statements are used here
+ * klm, 09-Oct-2022, 07-Nov-2022
+*/
+int jpsqlite_CatDELINS(char *db_name, struct CategoryAppInfo *cai) {
+	int sqlRet=0, errId=-1, i;
+	const char *sqlErr="";
+	sqlite3_stmt *dbpstmt;
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_CatDELINS()\n");
+
+	CHK(sqlite3_exec(db.conn,"BEGIN TRANSACTION",NULL,NULL,NULL),"jpsqlite_CatDELINS")
+
+	if (strcmp(db_name,"AddressDB") == 0) {
+		CHK(sqlite3_exec(db.conn,"delete from AddrCategory",NULL,NULL,NULL),"AddressCatDelEX");
+		CHK(sqlite3_prepare_v2(db.conn,
+			"insert into AddrCategory (Id, Label, InsertDate) "
+			"values (:Id, :Label, strftime('%Y-%m-%dT%H:%M:%S', 'now'))", -1, &dbpstmt, NULL), "jpAddrCatPRE")
+		jp_logf(JP_LOG_DEBUG,"\tAddress categories\n");
+		for (i=0; i<16; ++i) {
+			if (cai->name[i][0] == '\0') continue;
+			jp_logf(JP_LOG_DEBUG,"\t\t%2d %s\n",i,cai->name[i]);
+			errId = i;
+			CHK(sqlite3_bind_int(dbpstmt,1,i),"AddrCatB1")
+			CHK(sqlite3_bind_text(dbpstmt,2,cai->name[i],-1,SQLITE_STATIC),"AddrCatB2")
+			CHKDONE(sqlite3_step(dbpstmt),"AddrCatST")
+			CHK(sqlite3_clear_bindings(dbpstmt),"AddrCatCL")
+			CHK(sqlite3_reset(dbpstmt),"AddrCatRST")
+		}
+		CHK(sqlite3_finalize(dbpstmt),"AddrCatFIN")
+	} else if (strcmp(db_name,"MemoDB") == 0 || strcmp(db_name,"MemosDB-PMem") == 0 || strcmp(db_name,"Memo32DB") == 0) {
+		CHK(sqlite3_exec(db.conn,"delete from MemoCategory",NULL,NULL,NULL),"MemoCatDelEX");
+		CHK(sqlite3_prepare_v2(db.conn,
+			"insert into MemoCategory (Id, Label, InsertDate) "
+			"values (:Id, :Label, strftime('%Y-%m-%dT%H:%M:%S', 'now'))", -1, &dbpstmt, NULL), "jpMemCatINS")
+		for (i=0; i<16; ++i) {
+			if (cai->name[i][0] == '\0') continue;
+			jp_logf(JP_LOG_DEBUG,"\t\t%2d %s\n",i,cai->name[i]);
+			errId = i;
+			CHK(sqlite3_bind_int(dbpstmt,1,i),"MemCatB1")
+			CHK(sqlite3_bind_text(dbpstmt,2,cai->name[i],-1,SQLITE_STATIC),"MemCatB2")
+			CHKDONE(sqlite3_step(dbpstmt),"MemCatST")
+			CHK(sqlite3_clear_bindings(dbpstmt),"MemCatCL")
+			CHK(sqlite3_reset(dbpstmt),"MemCatRST")
+		}
+		CHK(sqlite3_finalize(dbpstmt),"MemCatFIN")
+	} else if (strcmp(db_name,"ToDoDB") == 0) {
+		CHK(sqlite3_exec(db.conn,"delete from ToDoCategory",NULL,NULL,NULL),"ToDoCatDelEX");
+		CHK(sqlite3_prepare_v2(db.conn,
+			"insert into ToDoCategory (Id, Label, InsertDate) "
+			"values (:Id, :Label, strftime('%Y-%m-%dT%H:%M:%S', 'now'))", -1, &dbpstmt, NULL),"jpToDoCatPRE")
+		for (i=0; i<16; ++i) {
+			if (cai->name[i][0] == '\0') continue;
+			jp_logf(JP_LOG_DEBUG,"\t\t%2d %s\n",i,cai->name[i]);
+			errId = i;
+			CHK(sqlite3_bind_int(dbpstmt,1,i),"ToDoCatB1")
+			CHK(sqlite3_bind_text(dbpstmt,2,cai->name[i],-1,SQLITE_STATIC),"ToDoCatB2")
+			CHKDONE(sqlite3_step(dbpstmt),"ToDoCatST")
+			CHK(sqlite3_clear_bindings(dbpstmt),"ToDoCatCL")
+			CHK(sqlite3_reset(dbpstmt),"ToDoCatRST")
+		}
+		CHK(sqlite3_finalize(dbpstmt),"ToDoCatFIN")
+	} else if (strcmp(db_name,"ExpenseDB") == 0) {
+		CHK(sqlite3_exec(db.conn,"delete from ExpenseCategory",NULL,NULL,NULL),"ExpenseCatDelEX");
+		CHK(sqlite3_prepare_v2(db.conn,
+			"insert into ExpenseCategory (Id, Label, InsertDate) "
+			"values (:Id, :Label, strftime('%Y-%m-%dT%H:%M:%S', 'now'))", -1, &dbpstmt, NULL),"jpExpenseCatPRE")
+		for (i=0; i<16; ++i) {
+			if (cai->name[i][0] == '\0') continue;
+			jp_logf(JP_LOG_DEBUG,"\t\t%2d %s\n",i,cai->name[i]);
+			errId = i;
+			CHK(sqlite3_bind_int(dbpstmt,1,i),"ExpenseCatB1")
+			CHK(sqlite3_bind_text(dbpstmt,2,cai->name[i],-1,SQLITE_STATIC),"ExpenseCatB2")
+			CHKDONE(sqlite3_step(dbpstmt),"ExpenseCatST")
+			CHK(sqlite3_clear_bindings(dbpstmt),"ExpenseCatCL")
+			CHK(sqlite3_reset(dbpstmt),"ExpenseCatRST")
+		}
+		CHK(sqlite3_finalize(dbpstmt),"ExpenseCatFIN")
+	}
+
+	CHK(sqlite3_exec(db.conn,"END TRANSACTION",NULL,NULL,NULL),"jpsqlite_CatDELINS")
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_CatDELINS(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_finalize(dbpstmt);
+	sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+
+
+int jpsqlite_PrefSEL(prefType prefs[], int count) {
+	int sqlRet=0, errId=0, id;
+	const char *sqlErr="", *name, *usertype, *filetype, *svalue;
+
+	for (errId=0; errId<count; ++errId) {
+		if ((sqlRet = sqlite3_step(db.stmtPrefSEL)) == SQLITE_DONE) break;
+		if (sqlRet != SQLITE_ROW) { sqlErr="PrefSELST"; goto err; }
+		id = sqlite3_column_int(db.stmtPrefSEL,0);
+		if (errId != id) { errId = id; jp_logf(JP_LOG_FATAL,"jpsqlite_PrefSEL(),stmtPrefSEL: errId != id"); }
+		//ALLOCN(prefs[errId].name,sqlite3_column_text(db.stmtPrefSEL,1),"pref[errId].name")
+		if (strcmp(name=sqlite3_column_text(db.stmtPrefSEL,1),prefs[errId].name) != 0) {
+			jp_logf(JP_LOG_FATAL,"jpsqlite_PrefSEL(),stmtPrefSEL: prefs[%d].name != %s\n",errId,name);
+		}
+		usertype = sqlite3_column_text(db.stmtPrefSEL,2);
+		filetype = sqlite3_column_text(db.stmtPrefSEL,3);
+		prefs[errId].ivalue = sqlite3_column_int(db.stmtPrefSEL,4);
+		svalue = sqlite3_column_text(db.stmtPrefSEL,5);
+		prefs[errId].usertype = (strcmp(usertype,"int") == 0) ? 1 : 2;
+		prefs[errId].filetype = (strcmp(filetype,"int") == 0) ? 1 : 2;
+		if (svalue == NULL) {
+			free(prefs[errId].svalue);
+			prefs[errId].svalue = NULL;
+			prefs[errId].svalue_size = 0;
+		} else if (strcmp(svalue,prefs[errId].svalue) != 0) {
+			free(prefs[errId].svalue);
+			ALLOCN(prefs[errId].svalue,svalue,"pref[errId].svalue")
+			prefs[errId].svalue_size = strlen(svalue) + 1;
+		}
+		/* * *
+		if (strcmp(usertype,"int") == 0) {
+			prefs[errId].ivalue = atoi(value);
+			prefs[errId].svalue = NULL;
+			prefs[errId].svalue_size = 0;
+		} else if (strcmp(type,"char") == 0) {
+			prefs[errId].ivalue = 0;
+			ALLOCN(prefs[errId].svalue,value,"pref[errId].svalue")
+			prefs[errId].svalue_size = strlen(value) + 1;
+		} else {	// this should not happen
+			jp_logf(JP_LOG_FATAL,"jpsqlite_PrefSEL(): at errId=%d unknown type %s\n",errId,type);
+			prefs[errId].ivalue = 0;
+			prefs[errId].svalue = NULL;
+			prefs[errId].svalue_size = 0;
+		}
+		* * */
+	}
+	CHK(sqlite3_clear_bindings(db.stmtPrefSEL),"PrefSELCL")	// not necessary, as currently there are no bindings
+	CHK(sqlite3_reset(db.stmtPrefSEL),"PrefSELRST")
+	return errId;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_PrefSEL(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_clear_bindings(db.stmtPrefSEL);
+	sqlite3_reset(db.stmtPrefSEL);
+	return 0;	// zero elements
+
+errAlloc:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_PrefSEL(): at errId=%d memory allocation error for %s\n",errId,sqlErr);
+	sqlite3_clear_bindings(db.stmtPrefSEL);
+	sqlite3_reset(db.stmtPrefSEL);
+	return 0;	// zero elements
+}
+
+
+
+int jpsqlite_PrefDELINS(prefType prefs[], int count) {
+	int sqlRet=0, errId=0, id;
+	const char *sqlErr="", *type, *value;
+	char prefLong[32];
+
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_PrefDELINS()\n");
+
+	CHK(sqlite3_exec(db.conn,"BEGIN TRANSACTION",NULL,NULL,NULL),"jpsqlite_PrefDELINS")
+	CHKDONE(sqlite3_step(db.stmtPrefDEL),"PrefDELST")
+	CHK(sqlite3_reset(db.stmtPrefDEL),"PrefDELRST")
+
+	for (id=0; id<count; ++id) {
+		CHK(sqlite3_bind_int(db.stmtPrefINS,1,id),"PrefInsB1")
+		CHK(sqlite3_bind_text(db.stmtPrefINS,2,prefs[id].name,-1,SQLITE_STATIC),"PrefInsB2")
+		CHK(sqlite3_bind_text(db.stmtPrefINS,3,prefs[id].usertype == 1 ? "int" : "char",-1,SQLITE_STATIC),"PrefInsB3")
+		CHK(sqlite3_bind_text(db.stmtPrefINS,4,prefs[id].filetype == 1 ? "int" : "char",-1,SQLITE_STATIC),"PrefInsB4")
+		CHK(sqlite3_bind_int(db.stmtPrefINS,5,prefs[id].ivalue),"PrefInsB5")
+		CHK(sqlite3_bind_text(db.stmtPrefINS,6,prefs[id].svalue,-1,SQLITE_STATIC),"PrefInsB6")
+		/* * *
+		if (prefs[errId].usertype == 1) {
+			CHK(sqlite3_bind_text(db.stmtPrefINS,3,"int",-1,SQLITE_STATIC),"PrefInsB3")
+			sprintf(prefLong,"%ld",prefs[errId].ivalue);
+			CHK(sqlite3_bind_text(db.stmtPrefINS,4,prefLong,-1,SQLITE_STATIC),"PrefInsB4")
+		} else if (prefs[errId].usertype == 2) {
+			CHK(sqlite3_bind_text(db.stmtPrefINS,3,"char",-1,SQLITE_STATIC),"PrefInsB3")
+			CHK(sqlite3_bind_text(db.stmtPrefINS,4,prefs[errId].svalue,-1,SQLITE_STATIC),"PrefInsB4")
+		} else {
+			jp_logf(JP_LOG_FATAL,"jpsqlite_PrefDELINS(): inserting unknown type %d at errId=%d",prefs[errId].usertype,errId);
+			CHK(sqlite3_bind_text(db.stmtPrefINS,3,"unknown",-1,SQLITE_STATIC),"PrefInsB3")
+			CHK(sqlite3_bind_text(db.stmtPrefINS,4,NULL,-1,SQLITE_STATIC),"PrefInsB4")
+		}
+		* * */
+		CHKDONE(sqlite3_step(db.stmtPrefINS),"PrefInsST")
+		CHK(sqlite3_clear_bindings(db.stmtPrefINS),"PrefInsCL")
+		CHK(sqlite3_reset(db.stmtPrefINS),"PrefRST")
+	}
+
+	CHK(sqlite3_exec(db.conn,"END TRANSACTION",NULL,NULL,NULL),"jpsqlite_PrefDELINS")
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_PrefSEL(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_clear_bindings(db.stmtPrefINS);
+	sqlite3_reset(db.stmtPrefINS);
+	sqlite3_reset(db.stmtPrefDEL);
+	sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_SUCCESS;
+}
+
+
+
+/* SELECTing from Alarms table. Not overly happy with this table, just containing a single column wiht a single row.
+ * klm, 20-Nov-2022
+*/
+int jpsqlite_AlarmsSEL(int *year, int *mon, int *day, int *hour, int *min) {
+	int sqlRet=0, errId=1;
+	const char *sqlErr="", *upToDate;
+	sqlite3_stmt *dbpstmt;
+
+	*year=0, *mon=0, *day=0, *hour=0, *min=0;
+
+	// Only queried once during the lifetime of the program
+	CHK(sqlite3_prepare_v2(db.conn, "select UpToDate from Alarms",
+		-1, &dbpstmt, NULL), "jpsqlite_AlarmsSEL")
+	if ((sqlRet = sqlite3_step(dbpstmt)) == SQLITE_ROW) {
+		upToDate = sqlite3_column_text(dbpstmt,0);
+		sscanf(upToDate,"%d-%d-%dT%d:%d",year,mon,day,hour,min);
+	}
+	jp_logf(JP_LOG_DEBUG,"jpsqlite_AlarmsSEL(): year=%04d, month=%02d, day=%02d, hour=%02d, min=%02d\n",*year,*mon,*day,*hour,*min);
+
+	CHK(sqlite3_reset(dbpstmt),"AlarmsSELRST")
+	CHK(sqlite3_finalize(dbpstmt),"AlarmsSELFIN")
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_alarmsSEL(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_finalize(dbpstmt);
+	return EXIT_FAILURE;
+}
+
+
+
+// klm, 20-Nov-2022
+int jpsqlite_AlarmsINS(struct tm *now) {
+	int sqlRet=0, errId=1;
+	const char *sqlErr="";
+	char upToDate[32];
+	sqlite3_stmt *dbpstmt;
+
+	CHK(sqlite3_exec(db.conn,"BEGIN TRANSACTION",NULL,NULL,NULL),"jpsqlite_AlarmsINS")
+	CHK(sqlite3_exec(db.conn,"delete from Alarms",NULL,NULL,NULL),"jpsqlite_AlarmsINS")
+
+	// Only inserted once during the lifetime of the program
+	CHK(sqlite3_prepare_v2(db.conn, "insert into Alarms(UpToDate) values (:UpToDate)",
+		-1, &dbpstmt, NULL), "jpsqlite_AlarmsINS")
+	strftime(upToDate,32,"%FT%R",now);
+	CHK(sqlite3_bind_text(dbpstmt,1,upToDate,-1,SQLITE_STATIC),"AlarmsInsB1")
+	CHKDONE(sqlite3_step(dbpstmt),"AlarmsInsST")
+	CHK(sqlite3_clear_bindings(dbpstmt),"AlarmsInsCL")
+	CHK(sqlite3_reset(dbpstmt),"AlarmsINSRST")
+	CHK(sqlite3_finalize(dbpstmt),"AlarmsINSFIN")
+
+	CHK(sqlite3_exec(db.conn,"END TRANSACTION",NULL,NULL,NULL),"jpsqlite_AlarmsINS")
+	return EXIT_SUCCESS;
+
+err:
+	jp_logf(JP_LOG_FATAL,"jpsqlite_AlarmsINS(): ret=%d, error=%s, Id=%d, rolling back\n%s\n",
+		sqlRet, sqlErr, errId, sqlite3_errmsg(db.conn));
+	sqlite3_finalize(dbpstmt);
+	sqlite3_exec(db.conn,"ROLLBACK TRANSACTION",NULL,NULL,NULL);
+	return EXIT_FAILURE;
+}
+
+

--- a/libsqlite.h
+++ b/libsqlite.h
@@ -1,0 +1,53 @@
+// J-Pilot SQLite3 header file
+// Elmar Klausmeier, 10-Oct-2022
+
+#include <pi-expense.h>
+
+// Global variable for SQLite-based data storage instead of Palm binary format
+extern int glob_sqlite;
+
+// Copied from expense.c
+struct MyExpense {
+	PCRecType rt;
+	unsigned int unique_id;
+	unsigned char attrib;
+	struct Expense ex;
+	struct MyExpense *next;
+};
+
+
+extern char *jpstrdup(const unsigned char *s);
+extern int jpsqlite_open(void);
+extern int jpsqlite_close(void);
+extern int jpsqlite_prepareAllStmt(void);
+extern int jpsqlite_AddrUPD(struct Address *addr, PCRecType rt, unsigned char attrib, unsigned int *unique_id);
+extern int jpsqlite_AddrINS(struct Address *addr, PCRecType rt, unsigned char attrib, unsigned int *unique_id);
+extern int jpsqlite_DatebookUPD(struct CalendarEvent *cale, PCRecType rt, unsigned char attrib, unsigned int *unique_id);
+extern int jpsqlite_DatebookINS(struct CalendarEvent *cale, PCRecType rt, unsigned char attrib, unsigned int *unique_id);
+extern int jpsqlite_MemoUPD(struct Memo *memo, PCRecType rt, unsigned char attrib, unsigned int *unique_id);
+extern int jpsqlite_MemoINS(struct Memo *memo, PCRecType rt, unsigned char attrib, unsigned int *unique_id);
+extern int jpsqlite_ToDoUPD(struct ToDo *todo, PCRecType rt, unsigned char attrib, unsigned int *unique_id);
+extern int jpsqlite_ToDoINS(struct ToDo *todo, PCRecType rt, unsigned char attrib, unsigned int *unique_id);
+extern int jpsqlite_ExpenseUPD(struct Expense *ex, PCRecType rt, unsigned char attrib, unsigned int *unique_id);
+extern int jpsqlite_ExpenseINS(struct Expense *ex, unsigned char attrib);
+extern int jpsqlite_Delete(AppType app_type, void *VP);
+extern int jpsqlite_prtAddrAppInfo(struct AddressAppInfo *ai);
+extern int jpsqlite_AddrLabelSEL(struct AddressAppInfo *ai);
+extern int jpsqlite_PhoneLabelSEL(struct AddressAppInfo *ai);
+extern int jpsqlite_AddrCatSEL(struct AddressAppInfo *ai);
+extern int jpsqlite_DatebookCatSEL(struct CalendarAppInfo *ai);
+extern int jpsqlite_MemoCatSEL(struct MemoAppInfo *ai);
+extern int jpsqlite_ToDoCatSEL(struct ToDoAppInfo *ai);
+extern int jpsqlite_ExpenseCatSEL(struct ExpenseAppInfo *ai);
+extern int jpsqlite_AddrSEL(AddressList **address_list, int sort_order, int privates, int category);
+extern int jpsqlite_DatebookSEL(CalendarEventList **calendar_event_list, struct tm *now, int privates);
+extern int jpsqlite_MemoSEL(MemoList **memo_list, int privates, int category);
+extern int jpsqlite_ToDoSEL(ToDoList **todo_list, int privates, int category);
+extern int jpsqlite_ExpenseSEL(struct MyExpense **expense_list);
+extern int jpsqlite_CatDELINS(char *db_name, struct CategoryAppInfo *cai);
+extern int jpsqlite_PrefSEL(prefType prefs[], int count);
+extern int jpsqlite_PrefDELINS(prefType prefs[], int count);
+extern int jpsqlite_AlarmsSEL(int *year, int *mon, int *day, int *hour, int *min);
+extern int jpsqlite_AlarmsINS(struct tm *now);
+
+

--- a/monthview_gui.c
+++ b/monthview_gui.c
@@ -35,6 +35,7 @@
 #include "calendar.h"
 #include "print.h"
 #include "jpilot.h"
+#include "libsqlite.h"
 
 /******************************* Global vars **********************************/
 extern int datebk_category;
@@ -323,7 +324,8 @@ static int display_months_appts(struct tm *date_in)
    memcpy(&date, date_in, sizeof(struct tm));
 
    /* Get all of the appointments */
-   get_days_calendar_events2(&ce_list, NULL, 2, 2, 2, CATEGORY_ALL, NULL);
+   if (glob_sqlite) jpsqlite_DatebookSEL(&ce_list,NULL,2);
+   else get_days_calendar_events2(&ce_list, NULL, 2, 2, 2, CATEGORY_ALL, NULL);
 
    get_month_info(date.tm_mon, 1, date.tm_year, &dow, &ndim);
 

--- a/prefs.c
+++ b/prefs.c
@@ -35,6 +35,7 @@
 #include "prefs.h"
 #include "log.h"
 #include "otherconv.h"
+#include "libsqlite.h"
 
 /********************************* Constants **********************************/
 #define NUM_SHORTDATES 7
@@ -49,12 +50,12 @@ static int t_fmt_ampm = TRUE;
 
 /* These are the default settings */
 /* name, usertype, filetype, ivalue, char *svalue, svalue_size; */
-static prefType glob_prefs[NUM_PREFS] = {
+/*static*/ prefType glob_prefs[NUM_PREFS] = {
    {"jpilotcss", CHARTYPE, CHARTYPE, 0, "jpilotcss.default", 16},
    {"time", CHARTYPE, INTTYPE, 0, NULL, 0},
    {"sdate", CHARTYPE, INTTYPE, 0, NULL, 0},
    {"ldate", CHARTYPE, INTTYPE, 0, NULL, 0},
-   {"xxx_internal1_xxx", CHARTYPE, INTTYPE, 0, NULL, 0},
+   {"xxx_internal1_xxx", CHARTYPE, INTTYPE, 0, NULL, 0},	// First Day Of the Week
    {"show_deleted", INTTYPE, INTTYPE, 0, NULL, 0},
    {"show_modified", INTTYPE, INTTYPE, 0, NULL, 0},
    {"todo_hide_completed", INTTYPE, INTTYPE, 0, NULL, 0},
@@ -213,7 +214,8 @@ void pref_init(void)
    }
 }
 
-void jp_pref_init(prefType prefs[], int count)
+#if 0
+void jp_pref_init(prefType prefs[], int count)	// unused function
 {
    int i;
 
@@ -227,7 +229,7 @@ void jp_pref_init(prefType prefs[], int count)
    }
 }
 
-void jp_free_prefs(prefType prefs[], int count)
+void jp_free_prefs(prefType prefs[], int count)	// unused function
 {
    int i;
 
@@ -238,6 +240,7 @@ void jp_free_prefs(prefType prefs[], int count)
       }
    }
 }
+#endif
 
 /* Get just the formatting for just the hour and am/pm if its set */
 /* datef needs to be preallocated */
@@ -869,7 +872,7 @@ int pref_read_rc_file(void)
 {
    int r;
 
-   r = jp_pref_read_rc_file(EPN".rc", glob_prefs, NUM_PREFS);
+   r = glob_sqlite ? jpsqlite_PrefSEL(glob_prefs,NUM_PREFS) : jp_pref_read_rc_file(EPN".rc", glob_prefs, NUM_PREFS);
 
    validate_glob_prefs();
 
@@ -905,6 +908,9 @@ int jp_pref_write_rc_file(char *filename, prefType prefs[], int num_prefs)
 
 int pref_write_rc_file(void)
 {
-   return jp_pref_write_rc_file(EPN".rc", glob_prefs, NUM_PREFS);
+	//return glob_rc_file_write ? jp_pref_write_rc_file(EPN".rc", glob_prefs, NUM_PREFS) : EXIT_SUCCESS;
+	if (glob_rc_file_write)
+		return glob_sqlite ? jpsqlite_PrefDELINS(glob_prefs,NUM_PREFS) : jp_pref_write_rc_file(EPN".rc", glob_prefs, NUM_PREFS);
+	return EXIT_SUCCESS;
 }
 

--- a/prefs.h
+++ b/prefs.h
@@ -160,6 +160,8 @@
 #define CHAR_SET_949_UTF  17 /* Korean (CP949) */
 #define NUM_CHAR_SETS     18
 
+extern prefType glob_prefs[];
+
 void pref_init(void);
 int pref_read_rc_file(void);
 int pref_write_rc_file(void);

--- a/prefs_gui.c
+++ b/prefs_gui.c
@@ -30,6 +30,7 @@
 #include "utils.h"
 #include "log.h"
 #include "plugins.h"
+#include "libsqlite.h"
 
 /******************************* Global vars **********************************/
 static GtkWidget *window;
@@ -596,13 +597,15 @@ void cb_prefs_gui(GtkWidget *widget, gpointer data) {
                      "changed", G_CALLBACK(cb_backups_entry),
                      NULL);
 
-    /* Show deleted files check box */
-    add_checkbutton(_("Show deleted records (default NO)"),
-                    PREF_SHOW_DELETED, vbox_settings, cb_checkbox_set_pref);
+	if (!glob_sqlite) {
+		/* Show deleted files check box */
+		add_checkbutton(_("Show deleted records (default NO)"),
+						PREF_SHOW_DELETED, vbox_settings, cb_checkbox_set_pref);
 
-    /* Show modified files check box */
-    add_checkbutton(_("Show modified deleted records (default NO)"),
-                    PREF_SHOW_MODIFIED, vbox_settings, cb_checkbox_set_pref);
+		/* Show modified files check box */
+		add_checkbutton(_("Show modified deleted records (default NO)"),
+						PREF_SHOW_MODIFIED, vbox_settings, cb_checkbox_set_pref);
+	}
 
     /* Confirm file installation */
     add_checkbutton(

--- a/search_gui.c
+++ b/search_gui.c
@@ -40,6 +40,7 @@
 #include "address.h"
 #include "todo.h"
 #include "memo.h"
+#include "libsqlite.h"
 
 #ifdef ENABLE_PLUGINS
 
@@ -108,7 +109,8 @@ static int search_datebook(const char *needle, GtkListStore *listStore, GtkTreeI
     /* Search Appointments */
     ce_list = NULL;
 
-    get_days_calendar_events2(&ce_list, NULL, 2, 2, 2, CATEGORY_ALL, NULL);
+    if (glob_sqlite) jpsqlite_DatebookSEL(&ce_list,NULL,2);
+    else get_days_calendar_events2(&ce_list, NULL, 2, 2, 2, CATEGORY_ALL, NULL);
 
     if (ce_list == NULL) {
         return 0;
@@ -220,7 +222,8 @@ static int search_address_or_contacts(const char *needle, GtkListStore *listStor
     /* Get addresses and move to a contacts structure, or get contacts directly */
     if (address_version == 0) {
         addr_list = NULL;
-        get_addresses2(&addr_list, SORT_ASCENDING, 2, 2, 2, CATEGORY_ALL);
+        if (glob_sqlite) jpsqlite_AddrSEL(&addr_list,addr_sort_order,2,CATEGORY_ALL);
+        else get_addresses2(&addr_list, SORT_ASCENDING, 2, 2, 2, CATEGORY_ALL);
         copy_addresses_to_contacts(addr_list, &cont_list);
         free_AddressList(&addr_list);
     } else {
@@ -287,7 +290,8 @@ static int search_todo(const char *needle, GtkListStore *listStore, GtkTreeIter 
     /* Search Appointments */
     todo_list = NULL;
 
-    get_todos2(&todo_list, SORT_DESCENDING, 2, 2, 2, 1, CATEGORY_ALL);
+    if (glob_sqlite) jpsqlite_ToDoSEL(&todo_list,1,CATEGORY_ALL);
+    else get_todos2(&todo_list, SORT_DESCENDING, 2, 2, 2, 1, CATEGORY_ALL);
 
     if (todo_list == NULL) {
         return 0;
@@ -361,7 +365,8 @@ static int search_memo(const char *needle, GtkListStore *listStore, GtkTreeIter 
     /* Search Memos */
     memo_list = NULL;
 
-    get_memos2(&memo_list, SORT_DESCENDING, 2, 2, 2, CATEGORY_ALL);
+    if (glob_sqlite) jpsqlite_MemoSEL(&memo_list,2,CATEGORY_ALL);
+    else get_memos2(&memo_list, SORT_DESCENDING, 2, 2, 2, CATEGORY_ALL);
 
     if (memo_list == NULL) {
         return 0;

--- a/utils.c
+++ b/utils.c
@@ -1596,7 +1596,7 @@ printf("fpn: initial weekly=%s\n", str);
                 freq = cale->repeatFrequency;
                 offset = ((date1->tm_year - cale->begin.tm_year) / freq) * freq;
 #ifdef ALARMS_DEBUG
-                                                                                                                                        printf("fpn: (%d - %d)%%%d\n", date1->tm_year, cale->begin.tm_year, freq);
+         printf("fpn: (%d - %d)%%%d\n", date1->tm_year, cale->begin.tm_year, freq);
          printf("fpn: years offset = %d\n", offset);
 #endif
                 add_years_to_date(&t, offset);
@@ -1620,7 +1620,7 @@ printf("fpn: initial weekly=%s\n", str);
         kill_update_next = 0;
         t_temp = mktime_dst_adj(&t);
 #ifdef ALARMS_DEBUG
-                                                                                                                                strftime(str, sizeof(str), "%B %d, %Y %H:%M", &t);
+      strftime(str, sizeof(str), "%B %d, %Y %H:%M", &t);
       printf("fpn: trying with=%s\n", str);
 #endif
 
@@ -1827,17 +1827,19 @@ int forward_backward_in_ce_time(const struct CalendarEvent *cale,
 }
 
 /* Displays usage string on supplied file handle */
-void fprint_usage_string(FILE *out) {
-    fprintf(out, "%s [ -v || -h || [-d] [-p] [-a || -A] [-s] [-i] [-geometry] ]\n", EPN);
+void fprint_usage_string(FILE *out) {	// only called from jpilot.c
+    fprintf(out, "%s [ -v || -h || [-d] [-p] [-a || -A] [-r] [-S] [-s] [-i] [-g] ]\n", EPN);
     fprintf(out, _(" -v display version and compile options\n"));
     fprintf(out, _(" -h display help text\n"));
     fprintf(out, _(" -d display debug info to stdout\n"));
     fprintf(out, _(" -p skip loading plugins\n"));
     fprintf(out, _(" -a ignore missed alarms since the last time program was run\n"));
     fprintf(out, _(" -A ignore all alarms past and future\n"));
+    fprintf(out, _(" -r no writing to rc-file or PREF table\n"));
+    fprintf(out, _(" -S store data in SQLite database\n"));
     fprintf(out, _(" -s start sync using existing instance of GUI\n"));
     fprintf(out, _(" -i iconify program immediately after launch\n"));
-    fprintf(out, _(" -geometry {X geometry} use specified geometry for main window\n\n"));
+    fprintf(out, _(" -g {X geometry} use specified geometry for main window\n\n"));
     fprintf(out, _(" The PILOTPORT and PILOTRATE environment variables specify\n"));
     fprintf(out, _(" which port to sync on, and at what speed.\n"));
     fprintf(out, _(" If PILOTPORT is not set then it defaults to /dev/pilot.\n"));
@@ -3759,15 +3761,16 @@ int unpack_db_header(DBHeader *dbh, unsigned char *buffer) {
  * to compare the jpilot version that produced the file with the jpilot
  * version that is importing the file. */
 int verify_csv_header(const char *header, int num_fields, const char *file_name) {
-    int i, comma_cnt;
+    int i, comma_cnt=0;
+    int n = strlen(header);
 
-    for (i = 0, comma_cnt = 0; i < strlen(header); i++) {
+    for (i=0; i<n; i++) {
         if (header[i] == ',') comma_cnt++;
     }
     if (comma_cnt != num_fields - 1) {
-        jp_logf(JP_LOG_WARN, _("Incorrect header format for CSV import\n"
+        jp_logf(JP_LOG_WARN, _("Incorrect header format for CSV import: comma#=%d, expected-1=%d\n"
                                "Check line 1 of file %s\n"
-                               "Aborting import\n"), file_name);
+                               "Aborting import\n"), comma_cnt,num_fields,file_name);
         return EXIT_FAILURE;
     }
 

--- a/utils.h
+++ b/utils.h
@@ -153,6 +153,12 @@ typedef recordid_t pi_uid_t;
 /* Unique ID used to locate a record, say after a search or GUI update */
 extern unsigned int glob_find_id;
 
+// Global variable for SQLite-based data storage instead of Palm binary format
+extern int glob_sqlite;
+
+// Global variable to inhibit rc-file writing
+extern int glob_rc_file_write;
+
 typedef enum {
    DATEBOOK = 100L,
    ADDRESS,

--- a/weekview_gui.c
+++ b/weekview_gui.c
@@ -35,6 +35,7 @@
 #include "calendar.h"
 #include "print.h"
 #include "jpilot.h"
+#include "libsqlite.h"
 
 /******************************* Global vars **********************************/
 extern int datebk_category;
@@ -197,7 +198,8 @@ static int display_weeks_appts(struct tm *date_in, GtkWidget **day_texts)
    }
 
    /* Get all of the appointments */
-   get_days_calendar_events2(&ce_list, NULL, 2, 2, 2, CATEGORY_ALL, NULL);
+   if (glob_sqlite) jpsqlite_DatebookSEL(&ce_list,NULL,2);
+   else get_days_calendar_events2(&ce_list, NULL, 2, 2, 2, CATEGORY_ALL, NULL);
 
    memcpy(&date, date_in, sizeof(struct tm));
 


### PR DESCRIPTION
This pull request adds 2 features, fixes some bugs, enhances search:
1. SQLite3 plugin, see [J-Pilot Plugin For SQLite Export](https://eklausmeier.goip.de/blog/2020/04-29-j-pilot-plugin-for-sqlite-export/)
2. Alternative to storing data in pdb/pc3-files, but instead all data in SQLite3, see [SQLite Storage for J-Pilot](https://eklausmeier.goip.de/blog/2022/12-04-sqlite-storage-for-j-pilot/), proposed here [Possible Enhancements to J-Pilot](https://eklausmeier.goip.de/blog/2013/02-27-enhancements-to-j-pilot/) -- J-Pilot can still be used with pdb/pc3-files as before
3. Crashes, see [Crashing J-Pilot](https://eklausmeier.goip.de/blog/2022/11-06-crashing-j-pilot/)
4. jpilot.c now uses `getopt()`, search in libplugin.c uses `strcasestr()`

Data model for SQLite storage is given here [SQL Datamodel For J-Pilot](https://eklausmeier.goip.de/blog/2020/04-27-sql-datamodel-for-j-pilot/).

I started development at Git commit 200d954 in the feature-gtk3 branch, but incorporated the changes contained in the later commits. Though, they lead to a warning during compilation, see [SQLite Storage for J-Pilot](https://eklausmeier.goip.de/blog/2022/12-04-sqlite-storage-for-j-pilot/), point __1__.

Since 04-Dec-2022 I use SQLite3-storage "in production", i.e., I use J-Pilot exclusively with this storage mode. Before that I made sure that J-Pilot works unchanged with the usual pdb/pc3-files.