### PR TITLE
Add Debian 12 build documentation and configure.ac advisory

### DIFF
--- a/docs/BUILDING_ON_DEBIAN12.md
+++ b/docs/BUILDING_ON_DEBIAN12.md
@@ -1,0 +1,195 @@
+# Building J-Pilot 2.0.2 on Debian 12 (Bookworm)
+
+**Prepared:** March 2026  
+**Author:** Neil Sinclair  
+**Platform tested:** Debian 12 (Bookworm), x86_64
+
+---
+
+## Background
+
+J-Pilot is not available in the Debian 12 package repositories — it was dropped after Debian 10 (Buster). The packagecloud.io repository referenced in the README (`https://packagecloud.io/install/repositories/judd/jpilot/script.deb.sh`) sets up the apt source correctly but contains no packages for Debian 12, resulting in `E: Unable to locate package jpilot`.
+
+Both J-Pilot and its dependency `pilot-link` must be built from source on Debian 12. This document records the steps required, including patches needed to work around incompatibilities between the pilot-link source and the versions of autoconf, automake, and libtool shipped with Debian 12.
+
+Pre-built `.deb` packages produced by this process are available alongside this document:
+
+- `pilot-link_0.12.5-1_amd64.deb`
+- `jpilot_2.0.2-1_amd64.deb`
+
+---
+
+## Quick Install (from pre-built .deb packages)
+
+If you just want to install on a Debian 12 machine without building from source:
+
+```bash
+sudo dpkg -i pilot-link_0.12.5-1_amd64.deb
+sudo dpkg -i jpilot_2.0.2-1_amd64.deb
+sudo apt-get install -f   # pulls in GTK, GLib, SQLite and other runtime dependencies automatically
+sudo /sbin/ldconfig
+sudo usermod -aG dialout $USER
+# Log out and back in for the group change to take effect
+```
+
+The `apt-get install -f` step is required because `dpkg` installs the package but does not automatically fetch dependencies — `apt-get install -f` resolves and installs them in a second pass. On a typical Debian 12 desktop most of these (GTK, GLib) will already be present.
+
+---
+
+## Building from Source
+
+### 1. Install build dependencies
+
+```bash
+sudo apt install \
+  build-essential autoconf automake libtool autopoint intltool \
+  libgtk-3-dev libgcrypt20-dev libsqlite3-dev \
+  libusb-1.0-0-dev libpopt-dev \
+  gettext checkinstall
+```
+
+Note: do **not** install `libbluetooth-dev` — see the Bluetooth section below.
+
+---
+
+### 2. Build pilot-link
+
+The upstream pilot-link source (from https://github.com/jichu4n/pilot-link) requires several patches to build on Debian 12. Apply them in order before running `autoreconf`.
+
+#### Clone
+
+```bash
+git clone https://github.com/jichu4n/pilot-link.git
+cd pilot-link
+```
+
+#### Patch 1 — Remove the broken BlueZ detection block
+
+The `configure.ac` file contains a BlueZ (Bluetooth) detection macro (`AC_BLUEZ`) that does not exist in the standard autoconf macro library. When autoconf expands it, it generates syntactically invalid shell code that causes `./configure` to abort with `syntax error near unexpected token ')'`.
+
+The fix is to remove the entire BlueZ detection block from `configure.ac` and replace it with empty substitutions so the Makefile variables are still defined:
+
+```bash
+# Remove lines 347–378 (the bluez detection block)
+sed -i '347,378d' configure.ac
+
+# Replace with a no-op conditional and empty variable substitutions
+sed -i '346a AM_CONDITIONAL([WITH_BLUEZ],[false])' configure.ac
+sed -i '/AM_CONDITIONAL(\[WITH_BLUEZ\]/a AC_SUBST([BLUEZ_CFLAGS],[])' configure.ac
+sed -i '/AC_SUBST(\[BLUEZ_CFLAGS\]/a AC_SUBST([BLUEZ_LIBS],[])' configure.ac
+```
+
+**Implication:** BlueZ (Bluetooth HotSync) support is disabled. This affects Palm devices that sync via Bluetooth. USB and serial HotSync (covering the vast majority of devices including Sony Clié and Handspring Visor) are unaffected. If Bluetooth sync is required, a correct `AC_BLUEZ` macro implementation would need to be written and contributed upstream.
+
+#### Patch 2 — Force bundled popt and remove broken nested detection
+
+The popt detection block uses deeply nested `AC_CHECK_HEADER` / `AC_CHECK_DECL` / `AC_CHECK_LIB` macros which generate broken shell code under Debian 12's autoconf. The fix is to force use of the bundled popt library (which ships with pilot-link) and remove the inner detection block:
+
+```bash
+# Force bundled popt
+sed -i 's/\[with_included_popt="auto"\]/[with_included_popt="yes"]/' configure.ac
+
+# Remove the now-redundant inner detection block (adjust line numbers if needed)
+# Check current line numbers with: grep -n 'with_included_popt' configure.ac
+sed -i '359,371d' configure.ac   # Remove inner if block
+sed -i '359d' configure.ac       # Remove orphaned fi
+sed -i '371,376d' configure.ac   # Remove orphaned else...fi
+```
+
+**Implication:** The system `libpopt` library is not used even if present. Pilot-link builds and statically links its own bundled popt. This has no practical impact on functionality.
+
+#### Regenerate and build
+
+```bash
+autoreconf -fi
+./configure --prefix=/usr/local
+make
+sudo make install
+sudo /sbin/ldconfig
+```
+
+#### Package with checkinstall
+
+```bash
+sudo rm -f /usr/local/share/aclocal/pilot-link.m4 \
+           /usr/local/lib/pkgconfig/pilot-link.pc \
+           /usr/local/lib/pkgconfig/pilot-link-pp.pc \
+           /usr/local/include/pi-*.h \
+           /usr/local/share/pilot-link/udev/60-libpisock.rules
+
+sudo checkinstall --pkgname=pilot-link --pkgversion=0.12.5 --pkgrelease=1 \
+  --pkglicense=GPL --pkggroup=libs \
+  --pkgsource="https://github.com/jichu4n/pilot-link" \
+  --nodoc \
+  make install
+```
+
+When prompted, clear the Requires field (field 10) and set your maintainer details.
+
+---
+
+### 3. Build J-Pilot
+
+```bash
+cd ~
+git clone https://github.com/juddmon/jpilot.git
+cd jpilot
+autoreconf -fi
+PKG_CONFIG_PATH=/usr/local/lib/pkgconfig ./configure --prefix=/usr/local
+make
+```
+
+#### Package with checkinstall
+
+```bash
+sudo make uninstall   # Clear any previous manual install
+sudo rm -rf /usr/local/share/doc/jpilot /usr/local/share/jpilot
+sudo mkdir -p /usr/local/share/doc/jpilot/icons \
+              /usr/local/share/doc/jpilot/manual \
+              /usr/local/share/jpilot
+
+sudo checkinstall --pkgname=jpilot --pkgversion=2.0.2 --pkgrelease=1 \
+  --pkglicense=GPL --pkggroup=utils \
+  --pkgsource="https://github.com/juddmon/jpilot" \
+  --nodoc \
+  make install
+```
+
+When prompted, set field 10 (Requires) to:
+
+```
+libgtk-3-0,libgdk-pixbuf-2.0-0,libglib2.0-0,libsqlite3-0,libgcrypt20
+```
+
+**Important:** the correct package name is `libgdk-pixbuf-2.0-0` with a hyphen before `2`, not `libgdk-pixbuf2.0-0` with a dot. Using the dot form will cause `dpkg` to fail with a dependency error on installation.
+
+Also set field 0 (Maintainer) to your name and email, then press Enter to build.
+
+---
+
+## USB HotSync setup
+
+Both Sony Clié and Handspring Visor devices use USB-serial adapters and will appear as `/dev/ttyUSB0`. Add your user to the `dialout` group:
+
+```bash
+sudo usermod -aG dialout $USER
+```
+
+Log out and back in. In J-Pilot preferences, set the port to `/dev/ttyUSB0`.
+
+---
+
+## Summary of configure.ac changes to pilot-link
+
+| Change | Reason | Impact |
+|--------|--------|--------|
+| Removed BlueZ detection block | `AC_BLUEZ` macro does not exist; generates broken shell code | Bluetooth HotSync disabled |
+| Added empty `BLUEZ_CFLAGS` and `BLUEZ_LIBS` substitutions | Makefile references these variables; without substitution the linker receives literal `@BLUEZ_LIBS@` as a filename | Required for build to succeed |
+| Forced bundled popt (`with_included_popt="yes"`) | Nested `AC_CHECK_*` macros generate broken shell under Debian 12 autoconf | Bundled popt used instead of system popt; no functional difference |
+| Removed inner popt detection block and orphaned `fi`/`else` | Left over after forcing bundled popt; caused shell syntax errors | None |
+
+---
+
+## Notes for upstream
+
+The `configure.ac` patches described above represent minimal fixes to make the source build on modern autoconf (2.71+) and automake (1.16+) as shipped with Debian 12. The ideal upstream fix would be to modernise `configure.ac` throughout — replacing deprecated macros (`AC_TRY_LINK`, `AM_PROG_MKDIR_P`, etc.), writing a proper `AC_BLUEZ` macro or replacing it with a standard `PKG_CHECK_MODULES` call, and updating the popt detection to avoid deeply nested `AC_CHECK_*` calls.

--- a/docs/UPSTREAM_ADVISORY_CONFIGURE_AC.md
+++ b/docs/UPSTREAM_ADVISORY_CONFIGURE_AC.md
@@ -1,0 +1,124 @@
+# Advisory: pilot-link build failures on modern autoconf (Debian 12 / Ubuntu 22.04+)
+
+**Date:** March 2026  
+**Affects:** pilot-link source from https://github.com/jichu4n/pilot-link  
+**Symptom:** `./configure` aborts with `syntax error near unexpected token ')'`  
+**Platforms confirmed affected:** Debian 12 (Bookworm), likely any distro shipping autoconf 2.71+ and automake 1.16+
+
+---
+
+## The problem
+
+The `configure.ac` file contains several constructs that generated valid shell code under older versions of autoconf but produce broken output under autoconf 2.71+. There are two distinct failure points.
+
+### Failure 1 — Missing `AC_BLUEZ` macro
+
+`configure.ac` calls `AC_BLUEZ(...)` to detect BlueZ Bluetooth support. This macro is not part of the standard autoconf library and is not defined anywhere in the source tree. When autoconf encounters an undefined macro used as a shell construct, it silently omits it — but the surrounding code (a `PKG_CHECK_MODULES` fallback block) is left structurally incomplete, producing a `fi,` with a trailing comma and orphaned `)` in the generated `configure` script.
+
+**The error:**
+```
+./configure: line XXXXX: syntax error near unexpected token `)'
+./configure: line XXXXX: `              )'
+```
+
+### Failure 2 — Deeply nested AC_CHECK_* macros in popt detection
+
+The popt library detection uses `AC_CHECK_HEADER` containing `AC_CHECK_DECL` containing `AC_CHECK_LIB`. This degree of nesting was tolerated by older autoconf but generates malformed shell under 2.71+, producing the same class of syntax error.
+
+---
+
+## Recommended fixes
+
+These are minimal fixes to unblock the build. See the "Ideal fix" section below for what a proper upstream patch would look like.
+
+### Fix 1 — BlueZ detection
+
+Remove the entire BlueZ detection block and replace with empty substitutions. The lines to remove will be approximately 347–378 in the current source — verify with:
+
+```bash
+grep -n 'bluetooth\|bluez\|BLUETOOTH' configure.ac
+```
+
+Replace the removed block with:
+
+```m4
+AM_CONDITIONAL([WITH_BLUEZ],[false])
+AC_SUBST([BLUEZ_CFLAGS],[])
+AC_SUBST([BLUEZ_LIBS],[])
+```
+
+**Impact:** BlueZ (Bluetooth HotSync) support is disabled. USB and serial HotSync are unaffected. The vast majority of Palm-era devices sync via USB or serial cradles; Bluetooth sync was only supported by a small number of later devices.
+
+If Bluetooth support is important to you, the correct fix is to write a proper `AC_BLUEZ` macro (or replace the whole block with a standard `PKG_CHECK_MODULES([BLUEZ],[bluez], ...)` call) and contribute it back upstream.
+
+### Fix 2 — popt detection
+
+Force use of the bundled popt library, which ships with pilot-link, and remove the now-redundant nested detection block. First, change the default in `configure.ac`:
+
+```bash
+sed -i 's/\[with_included_popt="auto"\]/[with_included_popt="yes"]/' configure.ac
+```
+
+Then remove the inner `if test "x$with_included_popt" != "xyes"` block and any orphaned `fi` / `else...fi` left behind. The exact line numbers will depend on your copy of the file — use `grep -n 'with_included_popt' configure.ac` to locate them before editing.
+
+**Impact:** The system `libpopt` library is not used even if present. Pilot-link uses its own bundled popt. There is no functional difference for HotSync operations.
+
+---
+
+## After patching
+
+Regenerate the build system from the patched `configure.ac`:
+
+```bash
+autoreconf -fi
+./configure --prefix=/usr/local
+make
+sudo make install
+sudo /sbin/ldconfig
+```
+
+---
+
+## Ideal upstream fix
+
+The patches above are intentionally minimal. A proper upstream fix would address the following:
+
+**Replace `AC_BLUEZ` with standard pkg-config detection:**
+```m4
+PKG_CHECK_MODULES([BLUEZ], [bluez],
+  [have_bluez=yes],
+  [have_bluez=no])
+AM_CONDITIONAL([WITH_BLUEZ], [test "$have_bluez" = "yes"])
+```
+
+**Replace nested AC_CHECK_* with a simpler popt check:**
+```m4
+PKG_CHECK_MODULES([POPT], [popt],
+  [with_included_popt=no],
+  [with_included_popt=yes])
+```
+
+**Modernise deprecated macros** throughout `configure.ac`. Autoconf will warn about all of these during `autoreconf`:
+
+| Deprecated | Replacement |
+|------------|-------------|
+| `AC_TRY_LINK` | `AC_LINK_IFELSE` |
+| `AC_TRY_COMPILE` | `AC_COMPILE_IFELSE` |
+| `AC_TRY_RUN` | `AC_RUN_IFELSE` |
+| `AC_HEADER_STDC` | (remove — C89 headers always present) |
+| `AC_HEADER_TIME` | (remove — sys/time.h always present) |
+| `AC_TYPE_SIGNAL` | (remove — signal handlers always void) |
+| `AM_PROG_MKDIR_P` | `AC_PROG_MKDIR_P` |
+| `AM_CONFIG_HEADER` | `AC_CONFIG_HEADERS` |
+| `AC_CANONICAL_SYSTEM` | `AC_CANONICAL_HOST` |
+| `AM_PROG_LIBTOOL` | `LT_INIT` |
+| `AC_HELP_STRING` | `AS_HELP_STRING` |
+| `AC_LIBTOOL_DLOPEN` | `LT_INIT([dlopen])` |
+
+Running `autoupdate` in the source tree will handle most of these automatically.
+
+---
+
+## Reporting
+
+If you've encountered this issue and applied these fixes, please consider opening a GitHub issue at https://github.com/jichu4n/pilot-link referencing this document. A pull request modernising `configure.ac` would benefit anyone trying to build on Debian 12, Ubuntu 22.04+, Fedora 38+, or any other distribution shipping autoconf 2.71+.


### PR DESCRIPTION
J-Pilot cannot be installed on Debian 12 via the packagecloud.io repository 
referenced in the README — the repo is configured but contains no packages 
for Debian 12 (Bookworm).

This PR adds two documentation files to the docs/ directory:

**BUILDING_ON_DEBIAN12.md** — complete build instructions for Debian 12, 
including two patches required to fix configure.ac incompatibilities with 
autoconf 2.71+. Pre-built .deb packages built using this process are 
available at: https://github.com/ThaGuMath/jpilot/releases/tag/v2.0.2-debian12

**UPSTREAM_ADVISORY_CONFIGURE_AC.md** — a technical explanation of the two 
configure.ac bugs (missing AC_BLUEZ macro and broken nested popt detection), 
the minimal fixes applied, and recommendations for a proper upstream fix.

Tested on Debian 12 (Bookworm) x86_64 using a clean Docker container.