### PR TITLE
Fix to built on macOS, sync to pilot-link Blob_t API, fall back to glibtoolize

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -12,8 +12,16 @@ rm -f configure Makefile Makefile.in config.h.in
 autopoint --force
 # Copy over scripts to allow internationalization
 intltoolize --force --copy --automake
-# Copy over scripts for libtool
-libtoolize --force --copy --automake
+# Copy over scripts for libtool (glibtoolize on macOS, libtoolize elsewhere)
+if command -v libtoolize >/dev/null 2>&1; then
+   LIBTOOLIZE=libtoolize
+elif command -v glibtoolize >/dev/null 2>&1; then
+   LIBTOOLIZE=glibtoolize
+else
+   echo "Error: neither libtoolize nor glibtoolize found in PATH" >&2
+   exit 1
+fi
+$LIBTOOLIZE --force --copy --automake
 
 # Update aclocal after other scripts have run
 aclocal -I m4

--- a/jp-contact.c
+++ b/jp-contact.c
@@ -54,7 +54,7 @@ int jp_pack_Contact(struct Contact *c, pi_buffer_t *buf)
    return pack_Contact(c, buf, contacts_v10);
 }
 
-int jp_Contact_add_blob(struct Contact *c, struct ContactBlob *blob)
+int jp_Contact_add_blob(struct Contact *c, Blob_t *blob)
 {
    return Contact_add_blob(c, blob);
 }

--- a/jp-pi-contact.h
+++ b/jp-pi-contact.h
@@ -48,7 +48,7 @@ extern int jp_pack_ContactAppInfo
     PI_ARGS((struct ContactAppInfo *, pi_buffer_t *buf));
 
 extern int jp_Contact_add_blob
-    PI_ARGS((struct Contact *, struct ContactBlob *));
+    PI_ARGS((struct Contact *, Blob_t *));
 extern int jp_Contact_add_picture
     PI_ARGS((struct Contact *, struct ContactPicture *));
 #ifdef __cplusplus


### PR DESCRIPTION
Small changes to `jp-pi-contact.h`, `jp-contact.c`: 

Update `jp_Contact_add_blob()` signature from `struct ContactBlob *` to `Blob_t *` to match pilot-link's API. The struct was renamed upstream in pilot-link commit [51d934b7](https://github.com/desrod/pilot-link/commit/51d934b73aa1fc55e997a96c39f012227d636960) (Sep 2021), leaving the jp shim with a dangling forward declaration that conflicts with the real prototype in `pi-contact.h`. Linux builds picked up the new header too, so this fixes the build on every current platform, not just macOS.

Another small fix to `autogen.sh`: 

This biases to `libtoolize` on Linux and falls back to `glibtoolize` when only the latter is present. Homebrew on macOS installs the GNU `libtool` tools with a 'g' prefix to avoid colliding with Apple's `/usr/bin/libtool`. Linux is unaffected here because `libtoolize` is found first.

<img width="1166" height="811" alt="Screenshot 2026-05-23 at 9 35 08 PM" src="https://github.com/user-attachments/assets/a91c8955-8fd8-4f0b-97f1-cf0b80012604" />

I verified this end-to-end on my macOS 26.5 machine (aarch64-apple-darwin) against pilot-link 0.15.0 installed at `/usr/local`. The whole tree now builds clean against pl 0.15.0 API and ABI.